### PR TITLE
fix(test): fix impossibility to launch universum main with arguments

### DIFF
--- a/universum.py
+++ b/universum.py
@@ -32,7 +32,7 @@ def define_arguments(*args):
         default_parser = "default"
         subparsers.add_parser(default_parser)
         if args:
-            args[0].insert(len(args), default_parser)
+            args[0].insert(len(args[0]), default_parser)
         else:
             sys.argv.insert(len(sys.argv), default_parser)
 


### PR DESCRIPTION
Previous implementation of simulated default subparser performed
adding the word "default" at incorrect position in the argument list
because it used length of the entire arguments tuple, not the length
of the first element, which is a list of command-line parameters.