### PR TITLE
fix(configs): unify usage of site packages

### DIFF
--- a/tests/configs.py
+++ b/tests/configs.py
@@ -10,7 +10,8 @@ def run_virtual(cmd):
 pylint_cmd = "universum_pylint --python-version 2 --rcfile pylintrc " + \
              "--files *.py _universum/ tests/ analyzers/ --result-file ${CODE_REPORT_FILE}"
 
-configs = Variations([dict(name="Create virtual environment", command=["python2", "-m", "virtualenv", env_name]),
+configs = Variations([dict(name="Create virtual environment",
+                           command=["python2", "-m", "virtualenv", env_name, "--system-site-packages"]),
                       dict(name="Install development",
                            command=run_virtual("pip --default-timeout=1200 install .[development]")),
                       dict(name="Make", artifacts="doc/_build", command=run_virtual("make")),


### PR DESCRIPTION
We didn't state this option as it is used by default; but some systems have different configurations
