### PR TITLE
refactor(automation server): split module into parts

### DIFF
--- a/_universum/modules/artifact_collector.py
+++ b/_universum/modules/artifact_collector.py
@@ -12,7 +12,7 @@ from ..lib.ci_exception import CriticalCiException, CiException
 from ..lib.gravity import Dependency
 from ..lib.utils import make_block
 from ..lib import utils
-from .automation_server import AutomationServer
+from .automation_server import AutomationServerForHostingBuild
 from .output import needs_output
 from .project_directory import ProjectDirectory
 from .reporter import Reporter
@@ -27,7 +27,7 @@ __all__ = [
 @needs_structure
 class ArtifactCollector(ProjectDirectory):
     reporter_factory = Dependency(Reporter)
-    automation_server_factory = Dependency(AutomationServer)
+    automation_server_factory = Dependency(AutomationServerForHostingBuild)
 
     @staticmethod
     def define_arguments(argument_parser):

--- a/_universum/modules/automation_server/automation_server.py
+++ b/_universum/modules/automation_server/automation_server.py
@@ -2,19 +2,17 @@
 
 from ...lib.gravity import Dependency, Module
 from ...lib import utils
-from .jenkins_server import JenkinsServer
+from .jenkins_server import JenkinsServerForHostingBuild, JenkinsServerForTrigger
 from .local_server import LocalServer
 from .teamcity_server import TeamcityServer
 
 __all__ = [
-    "AutomationServer"
+    "AutomationServerForHostingBuild",
+    "AutomationServerForTrigger"
 ]
 
 
 class AutomationServer(Module):
-    teamcity_driver_factory = Dependency(TeamcityServer)
-    local_driver_factory = Dependency(LocalServer)
-    jenkins_driver_factory = Dependency(JenkinsServer)
 
     @staticmethod
     def define_arguments(argument_parser):
@@ -24,15 +22,18 @@ class AutomationServer(Module):
                                  "local - user local terminal). TeamCity and Jenkins environment "
                                  "is detected automatically when launched on build agent")
 
+
+class AutomationServerForHostingBuild(AutomationServer):
+    teamcity_driver_factory = Dependency(TeamcityServer)
+    local_driver_factory = Dependency(LocalServer)
+    jenkins_driver_factory = Dependency(JenkinsServerForHostingBuild)
+
     def __init__(self, *args, **kwargs):
-        super(AutomationServer, self).__init__(*args, **kwargs)
+        super(AutomationServerForHostingBuild, self).__init__(*args, **kwargs)
         self.driver = utils.create_driver(teamcity_factory=self.teamcity_driver_factory,
                                           jenkins_factory=self.jenkins_driver_factory,
                                           local_factory=self.local_driver_factory,
                                           default=self.settings.type)
-
-    def trigger_build(self, revision):
-        return self.driver.trigger_build(revision)
 
     def report_build_location(self):
         return self.driver.report_build_location()
@@ -42,3 +43,20 @@ class AutomationServer(Module):
 
     def add_build_tag(self, tag):
         return self.driver.add_build_tag(tag)
+
+
+class AutomationServerForTrigger(AutomationServer):
+    teamcity_driver_factory = Dependency(TeamcityServer)
+    local_driver_factory = Dependency(LocalServer)
+    jenkins_driver_factory = Dependency(JenkinsServerForTrigger)
+
+    def __init__(self, *args, **kwargs):
+        super(AutomationServerForTrigger, self).__init__(*args, **kwargs)
+        self.driver = utils.create_driver(teamcity_factory=self.teamcity_driver_factory,
+                                          jenkins_factory=self.jenkins_driver_factory,
+                                          local_factory=self.local_driver_factory,
+                                          default=self.settings.type)
+
+    def trigger_build(self, revision):
+        return self.driver.trigger_build(revision)
+

--- a/_universum/modules/automation_server/base_server.py
+++ b/_universum/modules/automation_server/base_server.py
@@ -3,17 +3,24 @@
 from ...lib.gravity import Module
 
 __all__ = [
-    "BaseServer"
+    "BaseServerForTrigger",
+    "BaseServerForHostingBuild"
 ]
 
 
-class BaseServer(Module):
+class BaseServerForTrigger(Module):
     """
-    Abstract base class for API of automation (CI) server
+    Abstract base class for API of triggering builds on automation (CI) server
     """
 
     def trigger_build(self, revision):  # pylint: disable=no-self-use
         raise RuntimeError("Trigger build function is not defined for current driver.")
+
+
+class BaseServerForHostingBuild(Module):
+    """
+    Abstract base class for API of hosting CI builds on automation server
+    """
 
     def add_build_tag(self, tag):  # pylint: disable=no-self-use
         raise RuntimeError("Tag adding function is not defined for current driver.")

--- a/_universum/modules/automation_server/local_server.py
+++ b/_universum/modules/automation_server/local_server.py
@@ -1,13 +1,13 @@
 # -*- coding: UTF-8 -*-
 
-from .base_server import BaseServer
+from .base_server import BaseServerForHostingBuild, BaseServerForTrigger
 
 __all__ = [
     "LocalServer"
 ]
 
 
-class LocalServer(BaseServer):
+class LocalServer(BaseServerForHostingBuild, BaseServerForTrigger):
 
     def report_build_location(self):
         return "Local build. No external logs provided"

--- a/_universum/modules/automation_server/teamcity_server.py
+++ b/_universum/modules/automation_server/teamcity_server.py
@@ -3,14 +3,14 @@
 import requests
 
 from ...lib.module_arguments import IncorrectParameterError
-from .base_server import BaseServer
+from .base_server import BaseServerForHostingBuild, BaseServerForTrigger
 
 __all__ = [
     "TeamcityServer"
 ]
 
 
-class TeamcityServer(BaseServer):
+class TeamcityServer(BaseServerForHostingBuild, BaseServerForTrigger):
     @staticmethod
     def define_arguments(argument_parser):
         parser = argument_parser.get_or_create_group("TeamCity variables",

--- a/_universum/modules/launcher.py
+++ b/_universum/modules/launcher.py
@@ -218,7 +218,7 @@ class Launcher(ProjectDirectory):
     artifacts_factory = Dependency(artifact_collector.ArtifactCollector)
     api_support_factory = Dependency(api_support.ApiSupport)
     reporter_factory = Dependency(reporter.Reporter)
-    server_factory = Dependency(automation_server.AutomationServer)
+    server_factory = Dependency(automation_server.AutomationServerForHostingBuild)
     code_report_collector = Dependency(code_report_collector.CodeReportCollector)
 
     @staticmethod

--- a/_universum/modules/reporter.py
+++ b/_universum/modules/reporter.py
@@ -35,7 +35,7 @@ class ReportObserver(object):
 @needs_output
 @needs_structure
 class Reporter(Module):
-    automation_server_factory = Dependency(automation_server.AutomationServer)
+    automation_server_factory = Dependency(automation_server.AutomationServerForHostingBuild)
 
     @staticmethod
     def define_arguments(argument_parser):

--- a/_universum/poll.py
+++ b/_universum/poll.py
@@ -16,7 +16,7 @@ __all__ = ["Poll"]
 class Poll(Module):
     description = "Polling module of Universum"
     vcs_factory = Dependency(vcs.PollVcs)
-    server_factory = Dependency(automation_server.AutomationServer)
+    server_factory = Dependency(automation_server.AutomationServerForTrigger)
 
     @staticmethod
     def define_arguments(parser):


### PR DESCRIPTION
A single automation server was used by two universum modes:
main and poll. This led to incorrect help message
shown and to inability to check respective options
independently.

With this change applied it is now possible to correctly
display help for command-line parameters and check their
correctness.