### PR TITLE
feat: fix usage of check_required_option

### DIFF
--- a/_universum/lib/utils.py
+++ b/_universum/lib/utils.py
@@ -2,6 +2,7 @@
 
 import codecs
 import imp
+import inspect
 import os
 import sys
 import traceback
@@ -90,11 +91,9 @@ def format_traceback(exc, trace):
     return tb_text
 
 
-def check_required_option(settings, name, env_var):
-    if not getattr(settings, name, None):
-        text = "Variable '" + env_var + "' is not set. " + \
-               "Please set it or pass corresponding parameter via command line options"
-        raise IncorrectParameterError(text)
+def check_required_option(settings, setting_name, error_message):
+    if not getattr(settings, setting_name, None):
+        raise IncorrectParameterError(inspect.cleandoc(error_message))
 
 
 def catch_exception(exception_name, ignore_if=None):

--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -49,15 +49,30 @@ class PerforceVcs(base_vcs.BaseVcs):
         parser.add_argument("--p4-user", "-p4u", dest="user", help="P4 user name", metavar="P4USER")
         parser.add_argument("--p4-password", "-p4P", dest="password", help="P4 password", metavar="P4PASSWD")
 
-    def check_required_option(self, name, env_var):
-        utils.check_required_option(self.settings, name, env_var)
-
     def __init__(self, *args, **kwargs):
         super(PerforceVcs, self).__init__(*args, **kwargs)
 
-        self.check_required_option("port", "P4PORT")
-        self.check_required_option("user", "P4USER")
-        self.check_required_option("password", "P4PASSWD")
+        utils.check_required_option(self.settings, "port", """
+            the perforce 'port' is not specified.
+            
+            The perforce port defines protocol, host and listening port
+            of the perforce server. Please specify perforce port by
+            using '--p4-port' ('-p4p') command line parameter or
+            by setting P4PORT environment variable.""")
+        utils.check_required_option(self.settings, "user", """
+            the perforce user name is not specified.
+
+            The perforce user name is required to authenticate with
+            perforce server. Please specify the perforce user name by
+            using '--p4-user' ('-p4u') command line parameter or
+            by setting P4USER environment variable.""")
+        utils.check_required_option(self.settings, "password", """
+            the perforce password is not specified.
+
+            The perforce password is required to authenticate with
+            perforce server. Please specify the perforce password by
+            using '--p4-password' ('-p4P') command line parameter or
+            by setting P4PASSWD environment variable.""")
 
         try:
             p4_module = utils.import_module("P4")

--- a/_universum/modules/vcs/swarm.py
+++ b/_universum/modules/vcs/swarm.py
@@ -49,9 +49,6 @@ class Swarm(ReportObserver, Module):
         parser.add_argument("--swarm-fail-link", "-sfl", dest="fail_link", metavar="FAIL",
                             help="Swarm 'fail' link; is sent by Swarm triggering link as '{fail}'")
 
-    def check_required_option(self, name, env_var):
-        utils.check_required_option(self.settings, name, env_var)
-
     def __init__(self, user, password, *args, **kwargs):
         super(Swarm, self).__init__(*args, **kwargs)
         self.user = user
@@ -61,9 +58,37 @@ class Swarm(ReportObserver, Module):
         self.client_root = ""
         self.mappings_dict = {}
 
-        self.check_required_option("review_id", "REVIEW")
-        self.check_required_option("server_url", "SWARM_SERVER")
-        self.check_required_option("change", "SWARM_CHANGELIST")
+        utils.check_required_option(self.settings, "server_url", """
+            the URL of the Swarm server is not specified.
+
+            The URL is needed for communicating with swarm code review system:
+            getting review revision, posting comments, voting. Please specify 
+            the server URL by using '--swarm-server-url' ('-ssu') command
+            line parameter or by setting SWARM_SERVER environment variable.""")
+        utils.check_required_option(self.settings, "review_id", """
+            the Swarm review number is not specified.
+
+            The review number is needed for communicating with swarm code review system:
+            getting review revision, posting comments, voting. Please specify the number
+            by using '--swarm-review-id' ('-sre') command line parameter or by setting
+            REVIEW environment variable.
+            
+            In order to setup sending of the review number for pre-commit in Swarm,
+            please use the '{review}' argument in Automated Tests field of the Project
+            Settings.              
+            """)
+        utils.check_required_option(self.settings, "change", """
+            the Swarm changelist for unshelving is not specified.
+
+            The changelist is used for unshelving change before build and for
+            determining review revision. Please specify the changelist by using
+            '--swarm-change' ('-sch') command line parameter or by setting
+            SWARM_CHANGELIST environment variable.
+
+            In order to setup sending of the review number for pre-commit in Swarm,
+            please use the '{change}' argument in Automated Tests field of the Project
+            Settings.              
+            """)
 
         if " " in self.settings.change or "," in self.settings.change:
             raise IncorrectParameterError("SWARM_CHANGELIST takes only one CL number")

--- a/tests/test_argument_check.py
+++ b/tests/test_argument_check.py
@@ -45,6 +45,10 @@ def create_settings(test_type, vcs_type):
         if test_type == "main":
             settings.PerforceMainVcs.client = "p4_disposable_workspace"
             settings.PerforceMainVcs.force_clean = True
+            settings.MainVcs.report_to_review = True
+            settings.Swarm.review_id = "123"
+            settings.Swarm.change = "456"
+            settings.Swarm.server_url = "https://swarm"
 
         if test_type == "main" or test_type == "poll":
             settings.PerforceWithMappings.project_depot_path = "//depot"
@@ -78,18 +82,23 @@ def param(test_type, module, field, vcs_type="*", error_match=None):
     global missing_params
 
     if isinstance(vcs_type, list):
-        for vcs in vcs_type:
-            param(test_type, module, field, vcs, error_match)
+        for specific_vcs_type in vcs_type:
+            param(test_type, module, field, specific_vcs_type, error_match)
         return
 
     if vcs_type == "*":
         param(test_type, module, field, ["p4", "git", "none"], error_match)
         return
 
+    if test_type == "*":
+        for specific_test_type in ["main", "submit", "poll"]:
+            param(specific_test_type, module, field, vcs_type, error_match)
+        return
+
     if error_match is None:
         error_match = field
 
-    test_id = test_type + "-" + vcs_type + "-"+ module + "." + field
+    test_id = test_type + "-" + vcs_type + "-" + module + "." + field
     missing_params.append(pytest.param(test_type, module, field, vcs_type, error_match, id=test_id))
 
 
@@ -106,6 +115,12 @@ param("main",   "TeamcityServer",       "configuration_id")
 param("main",   "TeamcityServer",       "server_url",      error_match="TEAMCITY_SERVER")
 param("main",   "TeamcityServer",       "user_id",         error_match="TC_USER")
 param("main",   "TeamcityServer",       "passwd",          error_match="TC_PASSWD")
+param("*",      "PerforceVcs",          "port",            vcs_type="p4")
+param("*",      "PerforceVcs",          "user",            vcs_type="p4")
+param("*",      "PerforceVcs",          "password",        vcs_type="p4")
+param("main",   "Swarm",                "server_url",      vcs_type="p4", error_match="SWARM_SERVER")
+param("main",   "Swarm",                "review_id",       vcs_type="p4", error_match="REVIEW")
+param("main",   "Swarm",                "change",          vcs_type="p4")
 # pylint: enable = bad-whitespace
 
 


### PR DESCRIPTION
Previous implementation of check_required_option led
to too short unclear error messages. Fixed by adding
more details and explanations in all places, where it
was used.

This change is made in scope of task #271.