### PR TITLE
fix(jenkins_plugin): fix log displaying at job terminating

### DIFF
--- a/universum_log_collapser/pom.xml
+++ b/universum_log_collapser/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>universum_log_collapser</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>

--- a/universum_log_collapser/src/main/java/io/jenkins/plugins/universum_log_collapser/Annotator.java
+++ b/universum_log_collapser/src/main/java/io/jenkins/plugins/universum_log_collapser/Annotator.java
@@ -43,6 +43,7 @@ public class Annotator extends ConsoleAnnotator<Object> {
     private Pattern universumLogStartPattern = Pattern.compile("^==&gt; Universum \\d+\\.\\d+\\.\\d+ started execution$");
     private Pattern universumLogEndPattern = Pattern.compile("^==> Universum \\d+\\.\\d+\\.\\d+ finished execution$");
     private Pattern jenkinsLogEndPattern = Pattern.compile(".*Finished: .*");
+    private Pattern healthyLogPattern = Pattern.compile("^\\s+[\\|└]\\s+.*");
 
     public Annotator(Object context) {}
 
@@ -100,6 +101,11 @@ public class Annotator extends ConsoleAnnotator<Object> {
         }
 
         for (PaddingItem p : paddings) {
+            if (!healthyLogPattern.matcher(textStr).find()) {
+                logger.info("Log is broken, identation expected");
+                universumLogActive = false;
+                return this;
+            }
             text.addMarkup(p.position, "<span style=\"display: inline-block; " +
                 " width: " + (p.spacesNumber + 2) + "ch;\"></span>");
         }


### PR DESCRIPTION
# Description
fix(jenkins_plugin): fix log displaying at job terminating

There is no specific log line, which can indicate that job is stopped unexpectedly and following log is not Universum log. That's why skipping log processing, if some log without indentation appears in place were it should be with indentation.

Normal log example:
```
  |  step data...
  |  step data...
  |  step data...
```

Terminated log example:
```
  |  step data...
  |  step data...
Terminated
Build was aborted
```


Resolves #348 


# How Has This Been Tested?
Interrupt Jenkins build with Universum inside in various configuration and time moments.
