### PR TITLE
test(jenkins_plugin): add Java tests for log start, end, break

### DIFF
--- a/tests/configs.py
+++ b/tests/configs.py
@@ -22,7 +22,9 @@ configs = Variations([dict(name="Update Docker images", command=["make", "images
                       dict(name="Make tests", artifacts="htmlcov",
                            command=run_virtual("export LANG=en_US.UTF-8; make test")),
                       dict(name="Run static pylint", code_report=True,
-                           command=run_virtual("pip uninstall -y universum; " + pylint_cmd))])
+                           command=run_virtual("pip uninstall -y universum; " + pylint_cmd)),
+                      dict(name="Run Jenkins plugin Java tests",
+                           command=["mvn", "test"], directory="../../universum_log_collapser")])
 
 if __name__ == '__main__':
     print configs.dump()

--- a/tests/configs.py
+++ b/tests/configs.py
@@ -25,7 +25,7 @@ configs = Variations([dict(name="Update Docker images", command=["make", "images
                            command=run_virtual("pip uninstall -y universum; " + pylint_cmd)),
                       dict(name="Run Jenkins plugin Java tests", 
                            artifacts="universum_log_collapser/target/surefire-reports/*.xml",
-                           command=["mvn", "test"], directory="universum_log_collapser")])
+                           command=["mvn", "-B", "test"], directory="universum_log_collapser")])
 
 if __name__ == '__main__':
     print configs.dump()

--- a/tests/configs.py
+++ b/tests/configs.py
@@ -24,7 +24,7 @@ configs = Variations([dict(name="Update Docker images", command=["make", "images
                       dict(name="Run static pylint", code_report=True,
                            command=run_virtual("pip uninstall -y universum; " + pylint_cmd)),
                       dict(name="Run Jenkins plugin Java tests",
-                           command=["mvn", "test"], directory="../../universum_log_collapser")])
+                           command=["mvn", "test"], directory="universum_log_collapser")])
 
 if __name__ == '__main__':
     print configs.dump()

--- a/tests/configs.py
+++ b/tests/configs.py
@@ -23,7 +23,8 @@ configs = Variations([dict(name="Update Docker images", command=["make", "images
                            command=run_virtual("export LANG=en_US.UTF-8; make test")),
                       dict(name="Run static pylint", code_report=True,
                            command=run_virtual("pip uninstall -y universum; " + pylint_cmd)),
-                      dict(name="Run Jenkins plugin Java tests",
+                      dict(name="Run Jenkins plugin Java tests", 
+                           artifacts="universum_log_collapser/target/surefire-reports/*.xml",
                            command=["mvn", "test"], directory="universum_log_collapser")])
 
 if __name__ == '__main__':

--- a/tests/configs.py
+++ b/tests/configs.py
@@ -23,7 +23,7 @@ configs = Variations([dict(name="Update Docker images", command=["make", "images
                            command=run_virtual("export LANG=en_US.UTF-8; make test")),
                       dict(name="Run static pylint", code_report=True,
                            command=run_virtual("pip uninstall -y universum; " + pylint_cmd)),
-                      dict(name="Run Jenkins plugin Java tests", 
+                      dict(name="Run Jenkins plugin Java tests",
                            artifacts="universum_log_collapser/target/surefire-reports/*.xml",
                            command=["mvn", "-B", "test"], directory="universum_log_collapser")])
 

--- a/universum_log_collapser/.gitignore
+++ b/universum_log_collapser/.gitignore
@@ -3,3 +3,4 @@
 .project
 .settings
 target
+*.iml

--- a/universum_log_collapser/pom.xml
+++ b/universum_log_collapser/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>universum_log_collapser</artifactId>
-    <version>1.3</version>
+    <version>1.4</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>

--- a/universum_log_collapser/src/test/java/io/jenkins/plugins/universum_log_collapser/AnnotatorFactoryTest.java
+++ b/universum_log_collapser/src/test/java/io/jenkins/plugins/universum_log_collapser/AnnotatorFactoryTest.java
@@ -1,0 +1,14 @@
+package io.jenkins.plugins.universum_log_collapser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AnnotatorFactoryTest {
+
+    @Test
+    public void newInstance() {
+        Annotator annotator = new AnnotatorFactory<>().newInstance(null);
+        assertEquals(Annotator.class, annotator.getClass());
+    }
+}

--- a/universum_log_collapser/src/test/java/io/jenkins/plugins/universum_log_collapser/LogActiveTest.java
+++ b/universum_log_collapser/src/test/java/io/jenkins/plugins/universum_log_collapser/LogActiveTest.java
@@ -19,6 +19,10 @@ public class LogActiveTest {
     private static final String logStartLine = "==> Universum 1.2.3 started execution";
     private static final String logEndLine = "==> Universum 1.2.3 finished execution";
 
+    private static final String sectionStartClose = "</label></span><div>";
+    private static final String sectionEndClose = "</div><span class=\"nl\"></span>";
+    private static final String paddingSpan = "<span style=\"display: inline-block;  width: 4ch;\"></span>";
+
     public static class nonParametrizedTest {
 
         @Test
@@ -45,17 +49,17 @@ public class LogActiveTest {
                     " |   step data",
                     " └ [Success]",
                     replaceWithHtmlEntities(logStartLine),
-                    wrapSectionStart("1. Step name", 1),
-                    wrapSectionContent(" |   step data"),
-                    wrapSectionEnd(" └ [Success]"),
+                    sectionStartOpen(1) + "1. Step name" + sectionStartClose,
+                    paddingSpan + " |   step data",
+                    paddingSpan + " └ [Success]" + sectionEndClose,
                     replaceWithHtmlEntities(logEndLine),
                     "1. Step name",
                     " |   step data",
                     " └ [Success]",
                     replaceWithHtmlEntities(logStartLine),
-                    wrapSectionStart("1. Step name", 2),
-                    wrapSectionContent(" |   step data"),
-                    wrapSectionEnd(" └ [Success]"),
+                    sectionStartOpen(2) + "1. Step name" + sectionStartClose,
+                    paddingSpan + " |   step data",
+                    paddingSpan + " └ [Success]" + sectionEndClose,
             };
             checkAnnotation(in, out);
         }
@@ -74,13 +78,13 @@ public class LogActiveTest {
             };
             String[] out = new String[] {
                     replaceWithHtmlEntities(logStartLine),
-                    wrapSectionStart("1. Step name", 1),
-                    wrapSectionContent(" |   step data"),
-                    wrapSectionEnd(" └ [Success]"),
+                    sectionStartOpen(1) + "1. Step name" + sectionStartClose,
+                    paddingSpan + " |   step data",
+                    paddingSpan + " └ [Success]" + sectionEndClose,
                     "some random line",
-                    wrapSectionStart("1. Step name", 2),
-                    wrapSectionContent(" |   step data"),
-                    wrapSectionEnd(" └ [Success]")
+                    sectionStartOpen(2) + "1. Step name" + sectionStartClose,
+                    paddingSpan + " |   step data",
+                    paddingSpan + " └ [Success]" + sectionEndClose,
             };
             checkAnnotation(in, out);
         }
@@ -99,8 +103,8 @@ public class LogActiveTest {
             };
             String[] out = new String[] {
                     replaceWithHtmlEntities(logStartLine),
-                    wrapSectionStart("1. Step name", 1),
-                    wrapSectionContent(" |   step data"),
+                    sectionStartOpen(1) + "1. Step name" + sectionStartClose,
+                    paddingSpan + " |   step data",
                     "some random line",
                     " └ [Success]",
                     "1. Step name",
@@ -142,9 +146,9 @@ public class LogActiveTest {
                     " |   step data",
                     " └ [Success]",
                     replaceWithHtmlEntities(line),
-                    wrapSectionStart("1. Step name", 1),
-                    wrapSectionContent(" |   step data"),
-                    wrapSectionEnd(" └ [Success]"),
+                    sectionStartOpen(1) + "1. Step name" + sectionStartClose,
+                    paddingSpan + " |   step data",
+                    paddingSpan + " └ [Success]" + sectionEndClose,
             };
             checkAnnotation(in, out);
         }
@@ -227,9 +231,9 @@ public class LogActiveTest {
                     " |   step data",
                     " └ [Success]",
                     replaceWithHtmlEntities(logStartLine),
-                    wrapSectionStart("1. Step name", 1),
-                    wrapSectionContent(" |   step data"),
-                    wrapSectionEnd(" └ [Success]"),
+                    sectionStartOpen(1) + "1. Step name" + sectionStartClose,
+                    paddingSpan + " |   step data",
+                    paddingSpan + " └ [Success]" + sectionEndClose,
                     replaceWithHtmlEntities(line),
                     "1. Step name",
                     " |   step data",
@@ -277,13 +281,13 @@ public class LogActiveTest {
                     " |   step data",
                     " └ [Success]",
                     replaceWithHtmlEntities(logStartLine),
-                    wrapSectionStart("1. Step name", 1),
-                    wrapSectionContent(" |   step data"),
-                    wrapSectionEnd(" └ [Success]"),
+                    sectionStartOpen(1) + "1. Step name" + sectionStartClose,
+                    paddingSpan + " |   step data",
+                    paddingSpan + " └ [Success]" + sectionEndClose,
                     replaceWithHtmlEntities(line),
-                    wrapSectionStart("1. Step name", 2),
-                    wrapSectionContent(" |   step data"),
-                    wrapSectionEnd(" └ [Success]"),
+                    sectionStartOpen(2) + "1. Step name" + sectionStartClose,
+                    paddingSpan + " |   step data",
+                    paddingSpan + " └ [Success]" + sectionEndClose,
             };
             checkAnnotation(in, out);
         }
@@ -371,28 +375,13 @@ public class LogActiveTest {
         }
     }
 
-    private static String wrapSectionStart(String line, int idNum) {
-        return String.format("<input type=\"checkbox\" id=\"hide-block-%d\" class=\"hide\"/>", idNum) +
-                String.format("<label for=\"hide-block-%d\">", idNum) +
-                "<span class=\"sectionLbl\">" +
-                line +
-                "</label>" +
-                "</span>" +
-                "<div>";
-    }
-
-    private static String wrapSectionContent(String line) {
-        return "<span style=\"display: inline-block;  width: 4ch;\"></span>" + line;
-    }
-
-    private static String wrapSectionEnd(String line) {
-        return "<span style=\"display: inline-block;  width: 4ch;\"></span>" +
-                line +
-                "</div>" +
-                "<span class=\"nl\"></span>";
-    }
-
     private static String replaceWithHtmlEntities(String line) {
         return line.replaceAll(">", "&gt;").replaceAll("<", "&lt;");
+    }
+
+    private static String sectionStartOpen(int idNum) {
+        return String.format("<input type=\"checkbox\" id=\"hide-block-%d\" class=\"hide\"/>", idNum) +
+                String.format("<label for=\"hide-block-%d\">", idNum) +
+                "<span class=\"sectionLbl\">";
     }
 }

--- a/universum_log_collapser/src/test/java/io/jenkins/plugins/universum_log_collapser/LogActiveTest.java
+++ b/universum_log_collapser/src/test/java/io/jenkins/plugins/universum_log_collapser/LogActiveTest.java
@@ -1,0 +1,398 @@
+package io.jenkins.plugins.universum_log_collapser;
+
+import org.junit.Test;
+
+import hudson.MarkupText;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+import static org.junit.runners.Parameterized.Parameter;
+import static org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Enclosed.class)
+public class LogActiveTest {
+
+    private static final String logStartLine = "==> Universum 1.2.3 started execution";
+    private static final String logEndLine = "==> Universum 1.2.3 finished execution";
+
+    public static class nonParametrizedTest {
+
+        @Test
+        public void logStartStop() {
+            String[] in = new String[] {
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    logStartLine,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    logEndLine,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    logStartLine,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+            };
+            String[] out = new String[] {
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    replaceWithHtmlEntities(logStartLine),
+                    wrapSectionStart("1. Step name", 1),
+                    wrapSectionContent(" |   step data"),
+                    wrapSectionEnd(" └ [Success]"),
+                    replaceWithHtmlEntities(logEndLine),
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    replaceWithHtmlEntities(logStartLine),
+                    wrapSectionStart("1. Step name", 2),
+                    wrapSectionContent(" |   step data"),
+                    wrapSectionEnd(" └ [Success]"),
+            };
+            checkAnnotation(in, out);
+        }
+
+        @Test
+        public void logNotBroken() {
+            String[] in = new String[] {
+                    logStartLine,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    "some random line",
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]"
+            };
+            String[] out = new String[] {
+                    replaceWithHtmlEntities(logStartLine),
+                    wrapSectionStart("1. Step name", 1),
+                    wrapSectionContent(" |   step data"),
+                    wrapSectionEnd(" └ [Success]"),
+                    "some random line",
+                    wrapSectionStart("1. Step name", 2),
+                    wrapSectionContent(" |   step data"),
+                    wrapSectionEnd(" └ [Success]")
+            };
+            checkAnnotation(in, out);
+        }
+
+        @Test
+        public void logBroken() {
+            String[] in = new String[] {
+                    logStartLine,
+                    "1. Step name",
+                    " |   step data",
+                    "some random line",
+                    " └ [Success]",
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]"
+            };
+            String[] out = new String[] {
+                    replaceWithHtmlEntities(logStartLine),
+                    wrapSectionStart("1. Step name", 1),
+                    wrapSectionContent(" |   step data"),
+                    "some random line",
+                    " └ [Success]",
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]"
+            };
+            checkAnnotation(in, out);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LogStartPositiveTest {
+
+        @Parameter
+        public String line;
+
+        @Parameters(name="{0}")
+        public static Iterable<String> testData() {
+            return Arrays.asList(
+                    "==> Universum 1.2.3 started execution",
+                    "==> Universum 0.0.0 started execution",
+                    "==> Universum 1234.234521.952 started execution"
+            );
+        }
+
+        @Test
+        public void test() {
+            String[] in = new String[]{
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    line,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+            };
+            String[] out = new String[] {
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    replaceWithHtmlEntities(line),
+                    wrapSectionStart("1. Step name", 1),
+                    wrapSectionContent(" |   step data"),
+                    wrapSectionEnd(" └ [Success]"),
+            };
+            checkAnnotation(in, out);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LogStartNegativeTest {
+
+        @Parameter
+        public String line;
+
+        @Parameters(name="{0}")
+        public static Iterable<String> testData() {
+            return Arrays.asList(
+                    "==> Universum 1.2.3 finished execution",
+                    " ==> Universum 1.2.3 started execution",
+                    "=< Universum 1.2.3 started execution",
+                    "==> universum 1.2.3 started execution",
+                    "==> Universum 1.2 started execution",
+                    "==> Universum 1.2 started execution now"
+            );
+        }
+
+        @Test
+        public void test() {
+            String[] in = new String[]{
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    line,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+            };
+            String[] out = new String[] {
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    replaceWithHtmlEntities(line),
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+            };
+            checkAnnotation(in, out);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LogEndPositiveTest {
+
+        @Parameter
+        public String line;
+
+        @Parameters(name="{0}")
+        public static Iterable<String> testData() {
+            return Arrays.asList(
+                    "==> Universum 1.2.3 finished execution",
+                    "==> Universum 0.0.0 finished execution",
+                    "==> Universum 1234.234521.952 finished execution"
+            );
+        }
+
+        @Test
+        public void test() {
+            String[] in = new String[]{
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    logStartLine,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    line,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+            };
+            String[] out = new String[] {
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    replaceWithHtmlEntities(logStartLine),
+                    wrapSectionStart("1. Step name", 1),
+                    wrapSectionContent(" |   step data"),
+                    wrapSectionEnd(" └ [Success]"),
+                    replaceWithHtmlEntities(line),
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+            };
+            checkAnnotation(in, out);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class LogEndNegativeTest {
+
+        @Parameter
+        public String line;
+
+        @Parameters(name="{0}")
+        public static Iterable<String> testData() {
+            return Arrays.asList(
+                    "==> Universum 1.2.3 started execution",
+                    " ==> Universum 1.2.3 finished execution",
+                    "=< Universum 1.2.3 finished execution",
+                    "==> universum 1.2.3 finished execution",
+                    "==> Universum 1.2 finished execution",
+                    "==> Universum 1.2 finished execution now"
+            );
+        }
+
+        @Test
+        public void test() {
+            String[] in = new String[]{
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    logStartLine,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    line,
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+            };
+            String[] out = new String[] {
+                    "1. Step name",
+                    " |   step data",
+                    " └ [Success]",
+                    replaceWithHtmlEntities(logStartLine),
+                    wrapSectionStart("1. Step name", 1),
+                    wrapSectionContent(" |   step data"),
+                    wrapSectionEnd(" └ [Success]"),
+                    replaceWithHtmlEntities(line),
+                    wrapSectionStart("1. Step name", 2),
+                    wrapSectionContent(" |   step data"),
+                    wrapSectionEnd(" └ [Success]"),
+            };
+            checkAnnotation(in, out);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class JobFinishedPositiveTest {
+
+        @Parameter
+        public String line;
+
+        @Parameters(name="{0}")
+        public static Iterable<String> testData() {
+            // https://javadoc.jenkins-ci.org/hudson/model/Result.html
+            return Arrays.asList(
+                    "Finished: SUCCESS",
+                    "Finished: ABORTED",
+                    "Finished: FAILURE",
+                    "Finished: NOT_BUILT",
+                    "Finished: UNSTABLE"
+            );
+        }
+
+        @Test
+        public void test() {
+            String[] in = new String[]{
+                    line,
+                    logStartLine,
+                    line
+            };
+            String finishColoringIframe = "<iframe onload=\"finishColoring()\" style=\"display:none\"></iframe>";
+            String[] out = new String[] {
+                    line + finishColoringIframe,
+                    replaceWithHtmlEntities(logStartLine),
+                    line + finishColoringIframe
+            };
+            checkAnnotation(in, out);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class JobFinishedNegativeTest {
+
+        @Parameter
+        public String line;
+
+        @Parameters(name="{0}")
+        public static Iterable<String> testData() {
+            return Arrays.asList(
+                    " Finished: SUCCESS",
+                    "Finished: SUCCESS ",
+                    "Finished: ",
+                    "finish",
+                    "Finished: success"
+            );
+        }
+
+        @Test
+        public void test() {
+            String[] in = new String[]{
+                    logStartLine,
+                    line
+            };
+            String[] out = new String[] {
+                    replaceWithHtmlEntities(logStartLine),
+                    line
+            };
+            checkAnnotation(in, out);
+        }
+    }
+
+
+    private static void checkAnnotation(String[] in, String[] out) {
+        assertEquals(in.length, out.length);
+
+        Annotator annotator = new Annotator(null);
+        for (int i = 0; i < in.length; i++) {
+            MarkupText text = new MarkupText(in[i]);
+            Annotator result = annotator.annotate(null, text);
+
+            assertEquals(annotator, result);
+            System.out.println(out[i]);
+            System.out.println(text.toString(true));
+            assertEquals(out[i], text.toString(true));
+        }
+    }
+
+    private static String wrapSectionStart(String line, int idNum) {
+        return String.format("<input type=\"checkbox\" id=\"hide-block-%d\" class=\"hide\"/>", idNum) +
+                String.format("<label for=\"hide-block-%d\">", idNum) +
+                "<span class=\"sectionLbl\">" +
+                line +
+                "</label>" +
+                "</span>" +
+                "<div>";
+    }
+
+    private static String wrapSectionContent(String line) {
+        return "<span style=\"display: inline-block;  width: 4ch;\"></span>" + line;
+    }
+
+    private static String wrapSectionEnd(String line) {
+        return "<span style=\"display: inline-block;  width: 4ch;\"></span>" +
+                line +
+                "</div>" +
+                "<span class=\"nl\"></span>";
+    }
+
+    private static String replaceWithHtmlEntities(String line) {
+        return line.replaceAll(">", "&gt;").replaceAll("<", "&lt;");
+    }
+}


### PR DESCRIPTION
# Description
1. Java tests for log start, end and break added.
2. Make regexps for log end more specific.
3. Move processing of Jenkins log end to top of the function, because it was skipped as "non-Universum log".

Relates to #358