### PR TITLE
fix(jenkins_plugin): fix incorrect artifactId after directories structure change

### DIFF
--- a/universum_log_collapser/plugin/pom.xml
+++ b/universum_log_collapser/plugin/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
-    <artifactId>universum_log_collapser</artifactId>
+    <artifactId>plugin</artifactId>
     <version>1.5</version>
     <packaging>hpi</packaging>
     <properties>


### PR DESCRIPTION
# Description

Plugin was buildable, but did nothing after installation on Jenkins server.
This issue appeared after directories structure changes. "artifactId" field in pom.xml should be the same as project directory name.

# How Has This Been Tested?

Build plugin (`mvn package`) and install "plugin.hpi" on Jenkins server.