### PR TITLE
fix(plugin): fix collapsing with timestamps plugin usage

### DIFF
--- a/universum_log_collapser/plugin/pom.xml
+++ b/universum_log_collapser/plugin/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.5</version>
+    <version>1.6</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>

--- a/universum_log_collapser/plugin/src/main/java/io/jenkins/plugins/universum_log_collapser/Annotator.java
+++ b/universum_log_collapser/plugin/src/main/java/io/jenkins/plugins/universum_log_collapser/Annotator.java
@@ -30,7 +30,7 @@ public class Annotator extends ConsoleAnnotator<Object> {
     private List<PaddingItem> paddings = new ArrayList<>();
     private boolean universumLogActive = false;
 
-    private Pattern sectionStartPattern = Pattern.compile("(^[|\\s]*)(\\d+)\\..*");
+    private Pattern sectionStartPattern = Pattern.compile("^([|\\s]*)(\\d+)\\..*");
     private Pattern sectionEndPattern = Pattern.compile("^[|\\s]*└.*\\[[a-zA-Z]+].*");
     private Pattern sectionFailPattern = Pattern.compile("^[|\\s]*└.*\\[Failed].*");
     /*
@@ -40,8 +40,8 @@ public class Annotator extends ConsoleAnnotator<Object> {
         content without content processing.
      */
     private Pattern ignoredSectionPattern = Pattern.compile(".*Reporting build result.*");
-    private Pattern universumLogStartPattern = Pattern.compile("^==&gt; Universum \\d+\\.\\d+\\.\\d+ started execution$");
-    private Pattern universumLogEndPattern = Pattern.compile("^==&gt; Universum \\d+\\.\\d+\\.\\d+ finished execution$");
+    private Pattern universumLogStartPattern = Pattern.compile("^==> Universum \\d+\\.\\d+\\.\\d+ started execution$");
+    private Pattern universumLogEndPattern = Pattern.compile("^==> Universum \\d+\\.\\d+\\.\\d+ finished execution$");
     private Pattern jenkinsLogEndPattern = Pattern.compile("^Finished: [A-Z_]+$");
     private Pattern healthyLogPattern = Pattern.compile("^\\s+[|└]\\s+.*");
 
@@ -85,7 +85,7 @@ public class Annotator extends ConsoleAnnotator<Object> {
     */
     @Override
     public Annotator annotate(Object context, MarkupText text) {
-        String textStr = text.toString(true);
+        String textStr = text.getText();
         logger.info(textStr);
 
         Matcher jenkinsLogEndMatcher = jenkinsLogEndPattern.matcher(textStr);

--- a/universum_log_collapser/plugin/src/test/java/io/jenkins/plugins/universum_log_collapser/TestSuite.java
+++ b/universum_log_collapser/plugin/src/test/java/io/jenkins/plugins/universum_log_collapser/TestSuite.java
@@ -9,7 +9,7 @@ class TestSuite {
     static final String logStartLine = "==> Universum 1.2.3 started execution";
     static final String logEndLine = "==> Universum 1.2.3 finished execution";
 
-    static final String sectionStartClose = "</label></span><div>";
+    static final String sectionStartClose = "</span></label><div>";
     static final String sectionEndClose = "</div><span class=\"nl\"></span>";
     static final String sectionSpan = "<span class=\"sectionLbl\">";
     static final String paddingSpan = "<span style=\"display: inline-block;  width: 4ch;\"></span>";


### PR DESCRIPTION
# Description

When "Timestamper" plugin is enabled on Jenkins server, plugin stops collapsing.
Fixed by changing text string for regexps parsing. `text.getText()` will return raw Universum text without any wrapping tags.