### PR TITLE
fix(doc): incorrect flag name

### DIFF
--- a/doc/args.rst
+++ b/doc/args.rst
@@ -17,7 +17,7 @@ All command-line parameters, general and module-related, are passed to this main
     --version : @replace
         Display product name & version instead of launching.
 
-    --steps-filter -f : @replace
+    --filter -f : @replace
         | Allows to filter which steps to execute during launch.
          String value representing single filter or a set of filters separated by '**:**'.
          To define exclude pattern use '**!**' symbol at the beginning of the pattern.


### PR DESCRIPTION
Online documentation of **Universum 0.18.3** for flag **--filter** contain *console help* content. However it should contain another – extended description.