### PR TITLE
fix(jenkins_plugin): fix JS crash at steps coloring

### DIFF
--- a/universum_log_collapser/e2e/static_html.test.js
+++ b/universum_log_collapser/e2e/static_html.test.js
@@ -34,17 +34,19 @@ test("failed steps names colored", async() => {
     let spanColors = await page.$$eval(".sectionLbl", labels => {
         let result = [];
         for (let i = 0; i < labels.length; i++) {
-            result.push(labels[i].querySelector("span").style.color);
+            let innerSpan = labels[i].querySelector("span");
+            if (innerSpan != null) {
+                result.push(innerSpan.style.color);
+            }
         }
         return result;
     })
 
-    expect(spanColors).toHaveLength(5);
+    expect(spanColors).toHaveLength(4);
     expect(spanColors[0]).not.toBe("red");
     expect(spanColors[1]).toBe("red");
-    expect(spanColors[2]).toBe("red");
-    expect(spanColors[3]).not.toBe("red");
-    expect(spanColors[4]).toBe("red");
+    expect(spanColors[2]).not.toBe("red");
+    expect(spanColors[3]).toBe("red");
 });
 
 

--- a/universum_log_collapser/e2e/test.html
+++ b/universum_log_collapser/e2e/test.html
@@ -13,7 +13,7 @@ Building in workspace /var/lib/jenkins/workspace/universum
 ==> Universum 1.2.3 started execution
 <input type="checkbox" id="hide-block-1" class="hide"/><label for="hide-block-1"><span class="sectionLbl"><span style="color: #1E90FF;">1. Step name</span></span></label></span><div><span style="display: inline-block;  width: 4ch;"></span> |   step1 data
 <span style="display: inline-block;  width: 4ch;"></span> └ [Success]</div><span class="nl"></span><iframe onload="fix_pipeline()" style="display:none"></iframe>
-<input type="checkbox" id="hide-block-2" class="hide"/><label for="hide-block-2"><span class="sectionLbl"><span style="color: #1E90FF;">2. Step name</span></span></label><div><span style="display: inline-block;  width: 4ch;"></span> |   step2 data
+<input type="checkbox" id="hide-block-2" class="hide"/><label for="hide-block-2"><span class="sectionLbl">2. Step name</span></label><div><span style="display: inline-block;  width: 4ch;"></span> |   step2 data
 <span style="display: inline-block;  width: 4ch;"></span><span class="failed_result"> └ [Failed]</span></div><span class="nl"></span>
 <input type="checkbox" id="hide-block-3" class="hide"/><label for="hide-block-3"><span class="sectionLbl"><span style="color: #1E90FF;">3. Step name</span></span></label><div><span style="display: inline-block;  width: 4ch;"></span> |   step3 data
 <span style="display: inline-block;  width: 4ch;"></span><input type="checkbox" id="hide-block-4" class="hide"/><label for="hide-block-4"> |   <span class="sectionLbl"><span style="color: #1E90FF;">3.1. Step name</span></span></label><div><span style="display: inline-block;  width: 4ch;"></span> |   <span style="display: inline-block;  width: 4ch;"></span>   |   step3.1 data

--- a/universum_log_collapser/plugin/src/main/resources/io/jenkins/plugins/universum_log_collapser/Note/script.js
+++ b/universum_log_collapser/plugin/src/main/resources/io/jenkins/plugins/universum_log_collapser/Note/script.js
@@ -7,8 +7,11 @@ function colorLblsAscendant(el) {
     }
     var sectionLbl = el.getElementsByClassName("sectionLbl")[0];
     sectionLbl.style.color = "red";
-    sectionLbl.getElementsByTagName("span")[0].style.cssText = "color:red !important";
-    sectionLbl.parentElement.previousSibling.checked = true // expand failed section
+    var innerSpans = sectionLbl.getElementsByTagName("span");
+    if (innerSpans.length > 0) {
+        innerSpans[0].style.cssText = "color:red !important";
+    }
+    sectionLbl.parentElement.previousSibling.checked = true; // expand failed section
     var parent = el.parentNode;
     if (parent.className != "console-output") {
         colorLblsAscendant(parent.previousSibling);


### PR DESCRIPTION
# Description

Universum step name can be wrapped by <span> or not. Span absence is crashing JS code, which leads to stopping steps coloring after step without <span>.

Example:
```
<label for="hide-block-3">
    <span class="sectionLbl">
        <span style="color: #1E90FF;">
            3. Step name
        </span>
    </span>
</label>
```
or
```
<label for="hide-block-3">
    <span class="sectionLbl">
        3. Step name
    </span>
</label>
```