### PR TITLE
fix(p4): reverted files may no longer be accessible

### DIFF
--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -554,7 +554,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
             self.swarm.client_root = self.client_root
             self.swarm.mappings_dict = self.mappings_dict
 
-    @make_block("Cleaning workspace")
+    @make_block("Cleaning workspace", pass_errors=False)
     def clean_workspace(self):
         try:
             self.p4.client = self.client_name

--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -554,17 +554,17 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
             self.swarm.client_root = self.client_root
             self.swarm.mappings_dict = self.mappings_dict
 
-    @make_block("Cleaning workspace", pass_errors=False)
+    @make_block("Cleaning workspace")
     def clean_workspace(self):
         try:
             self.p4.client = self.client_name
-            report = self.p4.run_revert("//...")
+            report = self.p4.run_revert("-C", self.client_name, "-k", "//...")
             self.p4report(report)
             shelves = self.p4.run_changes("-c", self.client_name, "-s", "shelved")
             for item in shelves:
                 self.out.log("Deleting shelve from CL " + item["change"])
                 self.p4.run_shelve("-d", "-c", item["change"])
-            self.p4.run_revert("//...")
+            self.p4.run_revert("-C", self.client_name, "-k","//...")
             all_cls = self.p4.run_changes("-c", self.client_name, "-s", "pending")
             for item in all_cls:
                 self.out.log("Deleting CL " + item["change"])

--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -564,7 +564,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
             for item in shelves:
                 self.out.log("Deleting shelve from CL " + item["change"])
                 self.p4.run_shelve("-d", "-c", item["change"])
-            self.p4.run_revert("-C", self.client_name, "-k","//...")
+            self.p4.run_revert("-C", self.client_name, "-k", "//...")
             all_cls = self.p4.run_changes("-c", self.client_name, "-s", "pending")
             for item in all_cls:
                 self.out.log("Deleting CL " + item["change"])

--- a/tests/test_p4_exception_handling.py
+++ b/tests/test_p4_exception_handling.py
@@ -1,0 +1,67 @@
+# -*- coding: UTF-8 -*-
+# pylint: disable = redefined-outer-name
+
+import pytest
+
+import universum
+from tests.perforce_utils import P4Environment
+
+
+@pytest.fixture()
+def perforce_environment(perforce_workspace, tmpdir):
+    yield P4Environment(perforce_workspace, tmpdir, test_type="main")
+
+
+def test_p4_forbidden_local_revert(perforce_environment, capsys):
+    p4 = perforce_environment.p4
+    p4_file = perforce_environment.repo_file
+
+    config = """
+from _universum.configuration_support import Variations
+
+configs = Variations([dict(name="Restrict changes", command=["chmod", "-R", "555", "."]),
+                      dict(name="Check", command=["ls", "-la"])])
+"""
+    p4.run_edit(perforce_environment.depot)
+    p4_file.write(config)
+    change = p4.fetch_change()
+    change["Description"] = "CL for shelving"
+    shelve_cl = p4.save_change(change)[0].split()[1]
+    p4.run_shelve("-fc", shelve_cl)
+
+    settings = perforce_environment.settings
+    settings.PerforceMainVcs.shelve_cls = [shelve_cl]
+    settings.Launcher.config_path = p4_file.basename
+
+    result = universum.run(settings)
+    # Clean up the directory at once to make sure it doesn't remain non-writable even if some assert fails
+    perforce_environment.temp_dir.chmod(0777, rec=1)
+    perforce_environment.temp_dir.remove(rec=1)
+
+    assert result != 0
+    assert result != 0
+
+    assert "[Errno 13] Permission denied" in capsys.readouterr().err
+    # make sure submitter didn't leave any pending CLs in the workspace
+    assert not p4.run_changes("-c", perforce_environment.client_name, "-s", "pending")
+    # make sure submitter didn't leave any pending changes in default CL
+    assert not p4.run_opened("-C", perforce_environment.client_name)
+
+
+def test_p4_print_exception(perforce_environment, stdout_checker):
+    p4 = perforce_environment.p4
+    client = p4.fetch_client(perforce_environment.client_name)
+    client["Options"] = "noallwrite noclobber nocompress locked nomodtime normdir"
+    p4.save_client(client)
+
+    settings = perforce_environment.settings
+
+    result = universum.run(settings)
+    # Clean up the directory at once to make sure it doesn't remain non-writable even if some assert fails
+    client = p4.fetch_client(perforce_environment.client_name)
+    client["Options"] = "noallwrite noclobber nocompress unlocked nomodtime normdir"
+    p4.save_client(client)
+
+    assert result != 0
+    stdout_checker.assert_has_calls_with_param(
+        "Errors during command execution( \"p4 client -d {}\" )".format(perforce_environment.client_name))

--- a/tests/test_p4_exception_handling.py
+++ b/tests/test_p4_exception_handling.py
@@ -85,4 +85,3 @@ def test_p4_print_exception_in_finalize(perforce_environment, stdout_checker, ca
     stdout_checker.assert_has_calls_with_param(
         "Errors during command execution( \"p4 client -d {}\" )".format(perforce_environment.client_name))
     assert "CiException: [Errno 2] No such file or directory" in capsys.readouterr().err
-

--- a/tests/test_p4_exception_handling.py
+++ b/tests/test_p4_exception_handling.py
@@ -39,7 +39,6 @@ configs = Variations([dict(name="Restrict changes", command=["chmod", "-R", "555
     perforce_environment.temp_dir.remove(rec=1)
 
     assert result != 0
-    assert result != 0
 
     assert "[Errno 13] Permission denied" in capsys.readouterr().err
     # make sure submitter didn't leave any pending CLs in the workspace
@@ -55,9 +54,9 @@ def test_p4_print_exception(perforce_environment, stdout_checker):
     p4.save_client(client)
 
     settings = perforce_environment.settings
-
     result = universum.run(settings)
-    # Clean up the directory at once to make sure it doesn't remain non-writable even if some assert fails
+
+    # Update client at once to make sure it doesn't remain locked even if some assert fails
     client = p4.fetch_client(perforce_environment.client_name)
     client["Options"] = "noallwrite noclobber nocompress unlocked nomodtime normdir"
     p4.save_client(client)

--- a/tests/test_p4_revert_unshelved.py
+++ b/tests/test_p4_revert_unshelved.py
@@ -140,7 +140,7 @@ def perforce_environment(perforce_workspace, tmpdir):
     yield P4Environment(perforce_workspace, tmpdir, test_type="main")
 
 
-def test_p4_error_revert(perforce_environment, stdout_checker, capsys):
+def test_p4_error_revert(perforce_environment, capsys):
     p4 = perforce_environment.p4
     p4_file = perforce_environment.repo_file
 
@@ -168,9 +168,4 @@ configs = Variations([dict(name="Restrict changes", command=["chmod", "-R", "555
     perforce_environment.temp_dir.remove(rec=1)
 
     assert result != 0
-    # The following checks make sure all following actions were triggered despite unsuccessful:
-    # full revert, client deleting and sources clean up
-    stdout_checker.assert_has_calls_with_param("Errors during command execution( \"p4 revert //...\" )")
-    stdout_checker.assert_has_calls_with_param(
-        "Errors during command execution( \"p4 client -d {}\" )".format(perforce_environment.client_name))
     assert "[Errno 13] Permission denied" in capsys.readouterr().err

--- a/tests/test_p4_revert_unshelved.py
+++ b/tests/test_p4_revert_unshelved.py
@@ -4,10 +4,8 @@
 import os
 import pytest
 
-import universum
 from _universum.lib.gravity import construct_component
 from _universum.modules.vcs import perforce_vcs
-from .perforce_utils import P4Environment
 from . import utils
 
 
@@ -133,39 +131,3 @@ def test_p4_c_and_revert(diff_parameters):  # pylint: disable = too-many-locals
 
     for result, expected in zip(diff, expected_path):
         assert result == expected
-
-
-@pytest.fixture()
-def perforce_environment(perforce_workspace, tmpdir):
-    yield P4Environment(perforce_workspace, tmpdir, test_type="main")
-
-
-def test_p4_error_revert(perforce_environment, capsys):
-    p4 = perforce_environment.p4
-    p4_file = perforce_environment.repo_file
-
-    config = """
-from _universum.configuration_support import Variations
-
-configs = Variations([dict(name="Restrict changes", command=["chmod", "-R", "555", "."]),
-                      dict(name="Check", command=["ls", "-la"])])
-"""
-    p4.run_edit(perforce_environment.depot)
-    p4_file.write(config)
-    change = p4.fetch_change()
-    change["Description"] = "CL for shelving"
-    shelve_cl = p4.save_change(change)[0].split()[1]
-    p4.run_shelve("-fc", shelve_cl)
-
-    settings = perforce_environment.settings
-    settings.Launcher.output = "console"
-    settings.PerforceMainVcs.shelve_cls = [shelve_cl]
-    settings.Launcher.config_path = p4_file.basename
-
-    result = universum.run(settings)
-    # Clean up the directory at once to make sure it doesn't remain non-writable even if some assert fails
-    perforce_environment.temp_dir.chmod(0777, rec=1)
-    perforce_environment.temp_dir.remove(rec=1)
-
-    assert result != 0
-    assert "[Errno 13] Permission denied" in capsys.readouterr().err


### PR DESCRIPTION
This change fixes the rare bug, happening when files to be reverted by `finalize()` function are no longer accessible by P4. This might be a result of two scenarios:
1. actions done by Universum steps (e.g. `chmod` command in scripts)
2. desirable workspace name passed to Universum corresponds to a workspace that already exists and user running the Universum has no right to change files to be reverted in this workspace