### PR TITLE
fix(submit): create and delete real CL instead of using default

### DIFF
--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -159,18 +159,10 @@ class PerforceSubmitVcs(PerforceVcs, base_vcs.BaseSubmitVcs):
         client = self.p4.fetch_client(self.settings.client)
         workspace_root = client['Root']
 
-        # Make sure default CL is empty
-        try:
-            change = self.p4.fetch_change()
-            if "Files" in change:
-                text = "Default CL already contains the following files before reconciling:\n"
-                for line in change["Files"]:
-                    text += " * " + line + "\n"
-                text += "Submitting skipped"
-                self.out.log(text)
-                return 0
-        except P4Exception:
-            pass
+        change = self.p4.fetch_change()
+        change["Files"] = []
+        change["Description"] = description
+        change_id = self.p4.save_change(change)[0].split()[1]
 
         for file_path in file_list:
             # TODO: cover 'not file_path.startswith("/")' case with tests
@@ -179,32 +171,35 @@ class PerforceSubmitVcs(PerforceVcs, base_vcs.BaseSubmitVcs):
             if file_path.endswith("/"):
                 file_path += "..."
             if edit_only:
-                reconcile_result = self.p4reconcile("-e", convert_to_str(file_path))
+                reconcile_result = self.p4reconcile("-c", change_id, "-e", convert_to_str(file_path))
                 if not reconcile_result:
                     self.out.log("The file was not edited. Skipping '{}'...".format(os.path.relpath(file_path, workspace_root)))
             else:
-                reconcile_result = self.p4reconcile(convert_to_str(file_path))
+                reconcile_result = self.p4reconcile("-c", change_id, convert_to_str(file_path))
 
             for line in reconcile_result:
                 # p4reconcile returns list of dicts AND strings if file is opened in another workspace
                 # so we catch TypeError if line is not dict
                 try:
                     if line["action"] == "add":
-                        self.p4.run_reopen("-t", "+w", line["depotFile"])
+                        self.p4.run_reopen("-c", change_id, "-t", "+w", line["depotFile"])
                 except TypeError:
                     self.out.log(line)
 
-        current_cl = self.p4.fetch_change()
-        current_cl['Description'] = description
-
+        current_cl = self.p4.fetch_change(change_id)
         # If no changes were reconciled, there will be no file records in CL dictionary
         if "Files" not in current_cl:
+            self.p4.run_change("-d", change_id)
             return 0
 
-        result = self.p4.run_submit(current_cl, "-f", "revertunchanged")
-        cl_number = result[-1]['submittedChange']
+        try:
+            self.p4.run_submit(current_cl, "-f", "revertunchanged")
+        except Exception:
+            self.p4.run_revert("-k", "-c", change_id)
+            self.p4.run_change("-d", change_id)
+            raise
 
-        return cl_number
+        return change_id
 
 
 class PerforceWithMappings(PerforceVcs):

--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -146,6 +146,29 @@ class PerforceSubmitVcs(PerforceVcs, base_vcs.BaseSubmitVcs):
                 raise
             return []
 
+    def reconcile_one_path(self, file_path, workspace_root, change_id, edit_only):
+        # TODO: cover 'not file_path.startswith("/")' case with tests
+        if not file_path.startswith("/"):
+            file_path = workspace_root + "/" + file_path
+        if file_path.endswith("/"):
+            file_path += "..."
+        if edit_only:
+            reconcile_result = self.p4reconcile("-c", change_id, "-e", convert_to_str(file_path))
+            if not reconcile_result:
+                self.out.log(
+                    "The file was not edited. Skipping '{}'...".format(os.path.relpath(file_path, workspace_root)))
+        else:
+            reconcile_result = self.p4reconcile("-c", change_id, convert_to_str(file_path))
+
+        for line in reconcile_result:
+            # p4reconcile returns list of dicts AND strings if file is opened in another workspace
+            # so we catch TypeError if line is not dict
+            try:
+                if line["action"] == "add":
+                    self.p4.run_reopen("-c", change_id, "-t", "+w", line["depotFile"])
+            except TypeError:
+                self.out.log(line)
+
     @catch_p4exception()
     def submit_new_change(self, description, file_list, review=False, edit_only=False):
         self.connect()
@@ -166,26 +189,7 @@ class PerforceSubmitVcs(PerforceVcs, base_vcs.BaseSubmitVcs):
 
         try:
             for file_path in file_list:
-                # TODO: cover 'not file_path.startswith("/")' case with tests
-                if not file_path.startswith("/"):
-                    file_path = workspace_root + "/" + file_path
-                if file_path.endswith("/"):
-                    file_path += "..."
-                if edit_only:
-                    reconcile_result = self.p4reconcile("-c", change_id, "-e", convert_to_str(file_path))
-                    if not reconcile_result:
-                        self.out.log("The file was not edited. Skipping '{}'...".format(os.path.relpath(file_path, workspace_root)))
-                else:
-                    reconcile_result = self.p4reconcile("-c", change_id, convert_to_str(file_path))
-
-                for line in reconcile_result:
-                    # p4reconcile returns list of dicts AND strings if file is opened in another workspace
-                    # so we catch TypeError if line is not dict
-                    try:
-                        if line["action"] == "add":
-                            self.p4.run_reopen("-c", change_id, "-t", "+w", line["depotFile"])
-                    except TypeError:
-                        self.out.log(line)
+                self.reconcile_one_path(file_path, workspace_root, change_id, edit_only)
 
             current_cl = self.p4.fetch_change(change_id)
             # If no changes were reconciled, there will be no file records in CL dictionary

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -46,6 +46,29 @@ def test_fail_forbidden_branch(p4_submit_environment, branch):
     assert not p4.run_opened("-C", p4_submit_environment.client_name)
 
 
+def test_p4_success_files_in_default(p4_submit_environment):
+    p4 = p4_submit_environment.p4
+    p4_file = p4_submit_environment.repo_file
+    p4.run_edit(unicode(p4_file))
+    text = "This text should be in file"
+    p4_file.write(text + "\n")
+
+    file_name = utils.randomize_name("new_file") + ".txt"
+    new_file = p4_submit_environment.vcs_cooking_dir.join(file_name)
+    new_file.write("This is a new file" + "\n")
+
+    settings = copy.deepcopy(p4_submit_environment.settings)
+    setattr(settings.Submit, "reconcile_list", [unicode(new_file)])
+
+    assert not universum.run(settings)
+
+    check = False
+    for line in p4_file.readlines():
+        if text in line:
+            check = True
+    assert check
+
+
 class SubmitterParameters(object):
     def __init__(self, stdout_checker, environment):
         self.stdout_checker = stdout_checker

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -47,12 +47,14 @@ def test_p4_error_forbidden_branch(p4_submit_environment, branch):
 
 
 def test_p4_success_files_in_default(p4_submit_environment):
+    # This file should not be submitted, it should remain unchanged in default CL
     p4 = p4_submit_environment.p4
     p4_file = p4_submit_environment.repo_file
     p4.run_edit(unicode(p4_file))
     text = "This text should be in file"
     p4_file.write(text + "\n")
 
+    # This file should be successfully submitted
     file_name = utils.randomize_name("new_file") + ".txt"
     new_file = p4_submit_environment.vcs_cooking_dir.join(file_name)
     new_file.write("This is a new file" + "\n")
@@ -61,21 +63,18 @@ def test_p4_success_files_in_default(p4_submit_environment):
     setattr(settings.Submit, "reconcile_list", [unicode(new_file)])
 
     assert not universum.run(settings)
-
-    check = False
-    for line in p4_file.readlines():
-        if text in line:
-            check = True
-    assert check
+    assert text in p4_file.read()
 
 
 def test_p4_error_files_in_default_and_reverted(p4_submit_environment):
+    # This file should not be submitted, it should remain unchanged in default CL
     p4 = p4_submit_environment.p4
     p4_file = p4_submit_environment.repo_file
     p4.run_edit(unicode(p4_file))
     text_default = "This text should be in file"
     p4_file.write(text_default + "\n")
 
+    # This file must fail submit and remain unchanged while not checked out any more
     protected_dir = p4_submit_environment.vcs_cooking_dir.mkdir("write-protected")
     new_file = protected_dir.join(utils.randomize_name("new_file") + ".txt")
     text_new = "This is a new line in the file"
@@ -85,18 +84,8 @@ def test_p4_error_files_in_default_and_reverted(p4_submit_environment):
     setattr(settings.Submit, "reconcile_list", [unicode(new_file)])
 
     assert universum.run(settings)
-
-    check = False
-    for line in p4_file.readlines():
-        if text_default in line:
-            check = True
-    assert check
-
-    check = False
-    for line in new_file.readlines():
-        if text_new in line:
-            check = True
-    assert check
+    assert text_default in p4_file.read()
+    assert text_new in new_file.read()
 
 
 class SubmitterParameters(object):


### PR DESCRIPTION
If any changes are already checked out in default CL, they will be ignored.
If submitting fails, restoring all changes is guaranteed.
Resolves #388
Resolves #162 