### PR TITLE
fix(p4): one revert for whole client is admin only

### DIFF
--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -557,7 +557,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
     def clean_workspace(self):
         try:
             self.p4.client = self.client_name
-            report = self.p4.run_revert("-k", "//...")
+            report = self.p4.run_revert("-k", "-c", "default")
             self.p4report(report)
             shelves = self.p4.run_changes("-c", self.client_name, "-s", "shelved")
             for item in shelves:
@@ -566,7 +566,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
             all_cls = self.p4.run_changes("-c", self.client_name, "-s", "pending")
             for item in all_cls:
                 self.out.log("Deleting CL " + item["change"])
-                self.p4.run_revert("-k", "-c", item["change"], "//...")
+                self.p4.run_revert("-k", "-c", item["change"])
                 self.p4.run_change("-d", item["change"])
         except P4Exception as e:
             if "Client '{}' unknown".format(self.client_name) not in e.value \

--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -557,7 +557,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
     def clean_workspace(self):
         try:
             self.p4.client = self.client_name
-            report = self.p4.run_revert("-k", "-c", "default")
+            report = self.p4.run_revert("-k", "-c", "default", "//...")
             self.p4report(report)
             shelves = self.p4.run_changes("-c", self.client_name, "-s", "shelved")
             for item in shelves:
@@ -566,7 +566,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
             all_cls = self.p4.run_changes("-c", self.client_name, "-s", "pending")
             for item in all_cls:
                 self.out.log("Deleting CL " + item["change"])
-                self.p4.run_revert("-k", "-c", item["change"])
+                self.p4.run_revert("-k", "-c", item["change"], "//...")
                 self.p4.run_change("-d", item["change"])
         except P4Exception as e:
             if "Client '{}' unknown".format(self.client_name) not in e.value \

--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -199,7 +199,7 @@ class PerforceSubmitVcs(PerforceVcs, base_vcs.BaseSubmitVcs):
 
             self.p4.run_submit(current_cl, "-f", "revertunchanged")
         except Exception:
-            self.p4.run_revert("-k", "-c", change_id)
+            self.p4.run_revert("-k", "-c", change_id, "//...")
             self.p4.run_change("-d", change_id)
             raise
 

--- a/_universum/modules/vcs/perforce_vcs.py
+++ b/_universum/modules/vcs/perforce_vcs.py
@@ -557,16 +557,16 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
     def clean_workspace(self):
         try:
             self.p4.client = self.client_name
-            report = self.p4.run_revert("-C", self.client_name, "-k", "//...")
+            report = self.p4.run_revert("-k", "//...")
             self.p4report(report)
             shelves = self.p4.run_changes("-c", self.client_name, "-s", "shelved")
             for item in shelves:
                 self.out.log("Deleting shelve from CL " + item["change"])
                 self.p4.run_shelve("-d", "-c", item["change"])
-            self.p4.run_revert("-C", self.client_name, "-k", "//...")
             all_cls = self.p4.run_changes("-c", self.client_name, "-s", "pending")
             for item in all_cls:
                 self.out.log("Deleting CL " + item["change"])
+                self.p4.run_revert("-k", "-c", item["change"], "//...")
                 self.p4.run_change("-d", item["change"])
         except P4Exception as e:
             if "Client '{}' unknown".format(self.client_name) not in e.value \


### PR DESCRIPTION
Old command `p4 revert -C <client> //...` reverted all CLs in workspace.
Unfortunately, this command doesn't seem to work for non-admin users,
returning `[Error]: "You don't have permission for this operation."`
Reverting all CLs separately still works though.