### PR TITLE
fix(test): nonci test started to fail due to 'sh'

### DIFF
--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -33,7 +33,7 @@ def test_launcher_output(universum_runner_nonci):
     assert "Cleaning artifacts..." in console_out_log           # nonci cleans artifacts on project launch
     assert "Old artifact" not in console_out_log                # the artifacts are actually deleted
     assert file_output_expected not in console_out_log          # nonci doesn't write logs to the file by default
-    assert "Reporting build start" not in config                # nonci doesn't report build start
+    assert "Reporting build start" not in console_out_log       # nonci doesn't report build start
     assert "Copying sources" not in console_out_log             # nonci doesn't copy sources
     assert pwd_string_in_logs in console_out_log                # nonci launches step in the same directory
     assert "Cleaning copied sources" not in console_out_log     # nonci doesn't delete sources after work is done

--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -27,7 +27,8 @@ def test_launcher_output(universum_runner_nonci):
     file_output_expected = "Adding file /artifacts/test_step_log.txt to artifacts"
     pwd_string_in_logs = "pwd:[" + universum_runner_nonci.local.root_directory.strpath + "]"
 
-    universum_runner_nonci.environment.assert_successful_execution("bash -c 'mkdir /artifacts; echo \"Old artifact\" > /artifacts/test_nonci.txt'")
+    universum_runner_nonci.environment.assert_successful_execution(
+        "bash -c 'mkdir /artifacts; echo \"Old artifact\" > /artifacts/test_nonci.txt'")
 
     console_out_log = universum_runner_nonci.run(config)
     assert "Cleaning artifacts..." in console_out_log           # nonci cleans artifacts on project launch

--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -31,13 +31,17 @@ def test_launcher_output(universum_runner_nonci):
         "bash -c 'mkdir /artifacts; echo \"Old artifact\" > /artifacts/test_nonci.txt'")
 
     console_out_log = universum_runner_nonci.run(config)
-    assert "Cleaning artifacts..." in console_out_log           # nonci cleans artifacts on project launch
-    assert "Old artifact" not in console_out_log                # the artifacts are actually deleted
+
+    # the following logs are only present in the default mode of the universum
     assert file_output_expected not in console_out_log          # nonci doesn't write logs to the file by default
     assert "Reporting build start" not in console_out_log       # nonci doesn't report build start
     assert "Copying sources" not in console_out_log             # nonci doesn't copy sources
-    assert pwd_string_in_logs in console_out_log                # nonci launches step in the same directory
     assert "Cleaning copied sources" not in console_out_log     # nonci doesn't delete sources after work is done
+
+    # the following logs are specific to the nonci mode of the universum
+    assert "Cleaning artifacts..." in console_out_log           # nonci cleans artifacts on project launch
+    assert "Old artifact" not in console_out_log                # the artifacts are actually deleted
+    assert pwd_string_in_logs in console_out_log                # nonci launches step in the same directory
 
     # nonci doesn't require to clean artifacts between calls
     log = universum_runner_nonci.run(config, additional_parameters='-lo file')

--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -27,7 +27,7 @@ def test_launcher_output(universum_runner_nonci):
     file_output_expected = "Adding file /artifacts/test_step_log.txt to artifacts"
     pwd_string_in_logs = "pwd:[" + universum_runner_nonci.local.root_directory.strpath + "]"
 
-    universum_runner_nonci.environment.assert_successful_execution("bash -c 'echo \"Old artifact\" > /artifacts/test_nonci.txt'")
+    universum_runner_nonci.environment.assert_successful_execution("bash -c 'mkdir /artifacts; echo \"Old artifact\" > /artifacts/test_nonci.txt'")
 
     console_out_log = universum_runner_nonci.run(config)
     assert "Cleaning artifacts..." in console_out_log           # nonci cleans artifacts on project launch


### PR DESCRIPTION
The reason of the failure is that 'sh' changed the format of the
command line string returned for the launched process, and the
test is designed to check exactly one format.

Fixed the failure by avoiding checking of the command line
presence in logs at all.

Also, improved the test to check more features of the nonci mode.