### PR TITLE
fix(nonci): remove code report from nonci

### DIFF
--- a/_universum/modules/code_report_collector.py
+++ b/_universum/modules/code_report_collector.py
@@ -50,7 +50,6 @@ class CodeReportCollector(ProjectDirectory):
                     item["command"][enum] = item["command"][enum].replace(temp_filename, actual_filename)
 
             afterall_item = deepcopy(item)
-            afterall_item.update({"afterall": True})
             afterall_steps.append(afterall_item)
         return Variations(afterall_steps)
 

--- a/_universum/modules/launcher.py
+++ b/_universum/modules/launcher.py
@@ -425,12 +425,7 @@ class Launcher(ProjectDirectory):
         self.artifacts.clean_artifacts_silently()
 
         project_configs = self.process_project_configs()
-        afterall_configs = self.code_report_collector.prepare_environment(project_configs)
         self.artifacts.set_and_clean_artifacts(project_configs, ignore_existing_artifacts=True)
-
-        if afterall_configs:
-            self.launch_custom_configs(afterall_configs)
-            self.code_report_collector.report_code_report_results()
 
         self.launch_project()
         self.reporter.report_initialized = True

--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -5,7 +5,6 @@ import re
 import pytest
 
 
-@pytest.mark.nonci_applicable
 def test_code_report(universum_runner):
     config = """
 from _universum.configuration_support import Variations


### PR DESCRIPTION
The code report functionality lanches marked steps twice, but in
nonci mode it uses the same sources both times. Therefore, it cannot
compare results and there is no sense to process code report steps
separately. In addition, currently there is no way to report code
report results in nonci mode, because vcs and code review systems
are not used.

Also removed "afterall" key from generated steps in code report.
This key is not used anywhere.