### PR TITLE
fix(test): bug with launching python2

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -339,7 +339,7 @@ configs = Variations([dict(name="Long step", command=["sleep", "10"])]) * 5
     config_file = tmpdir.join("configs.py")
     config_file.write(config)
 
-    process = subprocess.Popen(["python", os.path.join(os.getcwd(), "universum.py"),
+    process = subprocess.Popen(["python3.7", os.path.join(os.getcwd(), "universum.py"),
                                 "-o", "console", "-vt", "none",
                                 "-pr", str(tmpdir.join("project_root")),
                                 "-ad", str(tmpdir.join("artifacts")),

--- a/universum.py
+++ b/universum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.7
+#!/usr/bin/env python3.7
 
 from __future__ import absolute_import
 from __future__ import print_function

--- a/universum_log_collapser/e2e/universum_live_log_to_html.py
+++ b/universum_log_collapser/e2e/universum_live_log_to_html.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3.7
 
 import os
 import subprocess


### PR DESCRIPTION
After fresh installation of python 3.7 on Ubuntu 18.04 from the
'deadsnakes' ppa, the 'python' command launches python version 2.
Version 2 failed to parse universum sources for version 3.

Also fixed shebangs according to linux recommendations.