### PR TITLE
fix(git): git module changed API in python 3

### DIFF
--- a/_universum/modules/vcs/git_vcs.py
+++ b/_universum/modules/vcs/git_vcs.py
@@ -267,9 +267,9 @@ class GitSubmitVcs(GitVcs):
         except git.exc.InvalidGitRepositoryError:
             raise CriticalCiException("'" + self.settings.project_root + "' does not contain a Git repository")
 
-        configurator = self.repo.config_writer()
-        configurator.set_value("user", "name", self.settings.user)
-        configurator.set_value("user", "email", self.settings.email)
+        with self.repo.config_writer() as configurator:
+            configurator.set_value("user", "name", self.settings.user)
+            configurator.set_value("user", "email", self.settings.email)
 
         file_list = [utils.parse_path(item, self.settings.project_root) for item in file_list]
         relative_path_list = [os.path.relpath(item, self.settings.project_root) for item in file_list]

--- a/tests/git_utils.py
+++ b/tests/git_utils.py
@@ -39,9 +39,9 @@ class GitServer:
                               _iter=True, _bg_exc=False, _bg=True,
                               _out=std_redirect, _err=std_redirect)
 
-        configurator = self._repo.config_writer()
-        configurator.set_value("user", "name", "Testing user")
-        configurator.set_value("user", "email", "some@email.com")
+        with self._repo.config_writer() as configurator:
+            configurator.set_value("user", "name", "Testing user")
+            configurator.set_value("user", "email", "some@email.com")
         self._file = self._working_directory.join(self.target_file)
         self._file.write("")
 


### PR DESCRIPTION
According to the documentation, to change config, user must
either explicitly call 'release' method or use context
managers.