### PR TITLE
fix(test): bug with nonci always False

### DIFF
--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -297,5 +297,5 @@ def nonci(request):
 
 
 def pytest_generate_tests(metafunc):
-    if hasattr(metafunc.function, 'nonci_applicable'):
+    if metafunc.definition.get_closest_marker('nonci_applicable'):
         metafunc.parametrize('nonci', (False, True), ids=('no subcmd', 'subcmd: nonci',))


### PR DESCRIPTION
In python 3 pytest changed its api for checking of custom marks.