### PR TITLE
fix(build): add build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ temp_config.py
 .mypy_cache
 .devcontainer
 .venv*
+build
+Universum.egg-info


### PR DESCRIPTION
pip 20.1 doesn't copy files to temp directory for building
package. This leads to build artifacts appearing in the
sources directory.
