### PR TITLE
feat(pylint): allow selecting exact python version

### DIFF
--- a/analyzers/pylint.py
+++ b/analyzers/pylint.py
@@ -25,13 +25,15 @@ class PylintAnalyzer:
     def define_arguments():
         parser = argparse.ArgumentParser(description="Pylint analyzer")
         parser.add_argument("--files", dest="file_list", nargs='+', required=True,
-                            help="Python files and Python packages for Pylint. " +
-                                 "Files could be defined as a single python file" +
+                            help="Python files and Python packages for Pylint. "
+                                 "Files could be defined as a single python file"
                                  " *.py or directories with __init__.py file in the directory.")
         parser.add_argument("--rcfile", dest="rcfile", type=str, help="Specify a configuration file.")
         parser.add_argument("--python-version", dest="version", default="3",
-                            choices=["2", "3", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"],
-                            help="Version of Python")
+                            help="Version of the python interpreter, such as 2, 3 or 3.7. "
+                                 "Pylint analyzer uses this parameter to select python binary for launching pylint. "
+                                 "For example, if the version is 3.7, it uses the following command: "
+                                 "'python3.7 -m pylint <...>'")
         utils.add_common_arguments(parser)
         return parser
 

--- a/analyzers/pylint.py
+++ b/analyzers/pylint.py
@@ -25,11 +25,12 @@ class PylintAnalyzer:
     def define_arguments():
         parser = argparse.ArgumentParser(description="Pylint analyzer")
         parser.add_argument("--files", dest="file_list", nargs='+', required=True,
-                            help="Python files and Python packages for Pylint. " + \
-                                 "Files could be defined as a single python file" + \
+                            help="Python files and Python packages for Pylint. " +
+                                 "Files could be defined as a single python file" +
                                  " *.py or directories with __init__.py file in the directory.")
         parser.add_argument("--rcfile", dest="rcfile", type=str, help="Specify a configuration file.")
-        parser.add_argument("--python-version", dest="version", default="3", choices=["2", "3"],
+        parser.add_argument("--python-version", dest="version", default="3",
+                            choices=["2", "3", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"],
                             help="Version of Python")
         utils.add_common_arguments(parser)
         return parser
@@ -45,7 +46,7 @@ class PylintAnalyzer:
         for pattern in self.settings.file_list:
             cmd.append(" ".join(glob.glob(pattern)))
 
-        result = subprocess.run(cmd, universal_newlines=True, #pylint: disable=subprocess-run-check
+        result = subprocess.run(cmd, universal_newlines=True,  # pylint: disable=subprocess-run-check
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         if result.returncode == 0:
@@ -79,7 +80,6 @@ class PylintAnalyzer:
             sys.stderr.write("The following string produced by the pylint launch cannot be parsed as JSON:\n")
             sys.stderr.write(issues)
             return 2
-
 
 
 def form_arguments_for_documentation():


### PR DESCRIPTION
The default versions of python depending on the version of
Ubuntu are listed below:

| Ubuntu code name  | Version | Python version |
| ----------------- | :-----: | :------------: |
| Precise Pangolin  |  12.04  |     3.2.3      |
| Quantal Quetzal   |  12.10  |     3.2.3      |
| Raring Ringtail   |  13.04  |     3.3.1      |
| Saucy Salamander  |  13.10  |     3.3.2      |
| Trusty Tahr       |  14.04  |     3.4.0      |
| Utopic Unicorn    |  14.10  |     3.4.2      |
| Vivid Vervet      |  15.04  |     3.4.3      |
| Wily Werewolf     |  15.10  |     3.4.3      |
| Xenial Xerus      |  16.04  |     3.5.1      |
| Yakkety Yak       |  16.10  |     3.5.1      |
| Zesty Zapus       |  17.04  |     3.5.3      |
| Aardvark Aardvark |  17.10  |     3.6.3      |
| Bionic Beaver     |  18.04  |     3.6.7      |
| Cosmic Cuttlefish |  18.10  |     3.6.6      |
| Disco Dingo       |  19.04  |     3.7.3      |
| Eoan Ermine       |  19.10  |     3.7.5      |
| Focal Fossa       |  20.04  |     3.8.2      |

Also fixed the formatting according to PyCharm requirements.
