### PR TITLE
fix(test): code report test only checked pylint analyzer

### DIFF
--- a/analyzers/pylint.py
+++ b/analyzers/pylint.py
@@ -70,8 +70,7 @@ class PylintAnalyzer:
             utils.analyzers_output(self.settings.result_file, issues_loads)
             if issues_loads:
                 return 1
-            else:
-                return 0
+            return 0
 
         except ValueError as e:
             sys.stderr.write(str(e))

--- a/analyzers/pylint.py
+++ b/analyzers/pylint.py
@@ -51,8 +51,6 @@ class PylintAnalyzer:
         result = subprocess.run(cmd, universal_newlines=True,  # pylint: disable=subprocess-run-check
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        if result.returncode == 0:
-            return 0
         if result.stderr and not result.stdout:
             sys.stderr.write(result.stderr)
             return result.returncode
@@ -60,9 +58,6 @@ class PylintAnalyzer:
         return self._handle_pylint_output(result.stdout)
 
     def _handle_pylint_output(self, issues: str) -> int:
-        if not issues:
-            return 0
-
         try:
             loads = json.loads(issues)
             issues_loads = []
@@ -72,10 +67,11 @@ class PylintAnalyzer:
                 issue["message"] = issue["message"].replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
                 issues_loads.append(issue)
 
+            utils.analyzers_output(self.settings.result_file, issues_loads)
             if issues_loads:
-                utils.analyzers_output(self.settings.result_file, issues_loads)
                 return 1
-            return 0
+            else:
+                return 0
 
         except ValueError as e:
             sys.stderr.write(str(e))

--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -1,4 +1,3 @@
-
 from typing import List
 import re
 import inspect
@@ -27,18 +26,16 @@ source_code = """
 print("Hello world.")
 """
 
-log_fail = r'Run static pylint - [^\n]*Failed'
-log_success = r'Run static pylint - [^\n]*Success'
+log_fail = r'Found [0-9]+ issues'
+log_success = r'Issues not found.'
 
 
 @pytest.mark.parametrize('args, tested_content, expected_log', [
     [["--result-file", "${CODE_REPORT_FILE}"], source_code, log_success],
-    [["--result-file", "${CODE_REPORT_FILE}"], source_code + '\n', log_fail],
+    [["--result-file", "${CODE_REPORT_FILE}"], source_code + '\n', log_fail]
 
-    [[], source_code, log_success],
-    [[], source_code + '\n', log_fail],
-    #TODO: add test with rcfile
-    #TODO: parametrize test for different versions of python
+    # TODO: add test with rcfile
+    # TODO: parametrize test for different versions of python
 ])
 @pytest.mark.nonci_applicable
 def test_code_report(runner_with_pylint, args, tested_content, expected_log):
@@ -56,7 +53,7 @@ from _universum.configuration_support import Variations
 
 configs = Variations([dict(name="Run usual command", command=["ls", "-la"])])
     """)
-    pattern = re.compile("(Found [0-9]+ issues|Issues not found.)")
+    pattern = re.compile(f"({log_fail}|{log_success})")
     assert not pattern.findall(log)
 
 
@@ -74,10 +71,10 @@ configs = Variations([dict(name="Run usual command", command=["ls", "-la"])])
      "error: the following arguments are required: --files"],
 ])
 @pytest.mark.nonci_applicable
-def test_code_report_wrong_params(runner_with_pylint, args, expected_log):
+def test_pylint_analyzer_wrong_params(runner_with_pylint, args, expected_log):
     source_file = runner_with_pylint.local.root_directory.join("source_file.py")
     source_file.write(source_code)
 
     log = runner_with_pylint.run(get_config(args))
-    assert re.findall(log_fail, log)
+    assert re.findall(r'Run static pylint - [^\n]*Failed', log)
     assert expected_log in log


### PR DESCRIPTION
Code report test contained checks only for verifying pylint analyzer
module, but it didn’t check the functionality of code report at all.
After fixing the test, it became clear that pylint analyzer doesn’t
produce any reports if there are no isseus. However, code report
always expects reports to be present. Fixed the pylint analyzer to
always produce report, even if there are no issues found.

Also removed code report tests that are producing output to stdout
instead of writing it to files, because code report module cannot
handle such output.