### PR TITLE
fix(test): perforce container starts slowly

### DIFF
--- a/tests/docker/perforce/run.sh
+++ b/tests/docker/perforce/run.sh
@@ -45,6 +45,8 @@ if [ ! -f $CONFIG_ROOT/$SERVER_NAME.conf ]; then
         -P $P4PASSWD \
         $SERVER_NAME
 
+    p4 -p $P4PORT configure set server=1
+
     echo Server info:
     p4 -p $P4PORT info
 else
@@ -59,5 +61,5 @@ PID_FILE=/var/run/p4d.$SERVER_NAME.pid
 # wait forever
 while true
 do
-  /usr/bin/tail --pid=$(cat $PID_FILE) -n 0 -f "$SERVER_ROOT/log" & wait ${!}
+  /usr/bin/tail --pid=$(cat $PID_FILE) -n 0 -f "$SERVER_ROOT/logs/log" & wait ${!}
 done


### PR DESCRIPTION
perforce has changed the structure of its log directories and 'tail'
command produces the error message in an endless loop. Because of
that, if the container is already started and tests attempt to reuse
it, it takes too much time to parse an enormous log. This happens
when running tests from the PyCharm.

Fixed by using correct path to logs file. Also, lowered the verbosity
level to 1. The default level is 3 and it produces too much logs.
