### PR TITLE
fix(test): disable seccomp to improve performance

### DIFF
--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -67,7 +67,8 @@ class ExecutionEnvironment:
                                                       volumes=self._volumes,
                                                       environment=self._environment,
                                                       auto_remove=True,
-                                                      detach=True)
+                                                      detach=True,
+                                                      security_opt=['seccomp=unconfined'])
         return True
 
     def get_working_directory(self):


### PR DESCRIPTION
seccomp filters syscalls that are available for applications inside
container. However, we use containers for testing only, so this added
security is not needed. At the same time, it significantly slows down
running of tests.
