### PR TITLE
hotfix: temporally disable entry points

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,6 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests', 'tests.*']),
     py_modules=['universum', 'analyzers.pylint', 'analyzers.svace', 'analyzers.uncrustify'],
-    # entry_points={'console_scripts': [
-    #     'universum = universum:main',
-    #     'universum_pylint = analyzers.pylint:main',
-    #     'universum_svace = analyzers.svace:main',
-    #     'universum_uncrustify = analyzers.uncrustify:main'
-    # ]},
     python_requires='>=3.7.5',
     setup_requires=['setuptools'],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,12 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['tests', 'tests.*']),
     py_modules=['universum', 'analyzers.pylint', 'analyzers.svace', 'analyzers.uncrustify'],
-    entry_points={'console_scripts': [
-        'universum = universum:main',
-        'universum_pylint = analyzers.pylint:main',
-        'universum_svace = analyzers.svace:main',
-        'universum_uncrustify = analyzers.uncrustify:main'
-    ]},
+    # entry_points={'console_scripts': [
+    #     'universum = universum:main',
+    #     'universum_pylint = analyzers.pylint:main',
+    #     'universum_svace = analyzers.svace:main',
+    #     'universum_uncrustify = analyzers.uncrustify:main'
+    # ]},
     python_requires='>=3.7.5',
     setup_requires=['setuptools'],
     install_requires=[

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -232,7 +232,7 @@ class UniversumRunner:
 
         # We cannot collect coverage from installed module, so we run it only if specifically told so
         if force_installed:
-            cmd = "universum"
+            cmd = "python3.7 -m universum"
 
         if self.nonci:
             cmd += ' nonci'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,12 +5,12 @@ config = """
 from _universum.configuration_support import Variations
 
 configs = Variations([dict(name="Run script", artifacts="output.json",
-                           command=["bash", "-c", "universum api file-diff > output.json"])])
+                           command=["bash", "-c", "python3.7 -m universum api file-diff > output.json"])])
 """
 
 
 def test_error_wrong_environment(docker_main_and_nonci):
-    log = docker_main_and_nonci.environment.assert_unsuccessful_execution("universum api file-diff")
+    log = docker_main_and_nonci.environment.assert_unsuccessful_execution("python3.7 -m universum api file-diff")
     assert "Error: Failed to read the 'UNIVERSUM_DATA_FILE' from environment" in log
 
 

--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -17,7 +17,7 @@ def get_config(args: List[str]):
         from _universum.configuration_support import Variations
 
         configs = Variations([dict(name="Run static pylint", code_report=True,
-            command=['universum_pylint'{''.join(args)}])])
+            command=['python3.7', '-m', 'analyzers.pylint'{''.join(args)}])])
     """)
 
 


### PR DESCRIPTION
While transferring from Python2.7 to Python3.7 entry points interfere with each other. Will be turned on later.