### PR TITLE
feat(nonci): set project root to current directory

### DIFF
--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -94,8 +94,8 @@ class ExecutionEnvironment:
     def assert_successful_execution(self, cmd, environment=None, workdir=None):
         return self._run_and_check(cmd, True, environment=environment, workdir=workdir)
 
-    def assert_unsuccessful_execution(self, cmd, environment=None):
-        return self._run_and_check(cmd, False, environment=environment,workdir=workdir)
+    def assert_unsuccessful_execution(self, cmd, environment=None, workdir=None):
+        return self._run_and_check(cmd, False, environment=environment, workdir=workdir)
 
     def install_python_module(self, name):
         if os.path.exists(name):

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -72,10 +72,10 @@ class ExecutionEnvironment:
     def get_working_directory(self):
         return self._work_dir
 
-    def _run_and_check(self, cmd, result, environment):
+    def _run_and_check(self, cmd, result, environment, workdir):
         if not environment:
             environment = []
-        process_id = self._client.api.exec_create(self._container.id, cmd, environment=environment)
+        process_id = self._client.api.exec_create(self._container.id, cmd, environment=environment, workdir=workdir)
         print("$ " + cmd)
         log = self._client.api.exec_start(process_id)
         assert not isinstance(str, type(log)), "Looks like it's a bug in a docker 4.1.0. According to documentation " \
@@ -91,11 +91,11 @@ class ExecutionEnvironment:
 
         return log
 
-    def assert_successful_execution(self, cmd, environment=None):
-        return self._run_and_check(cmd, True, environment=environment)
+    def assert_successful_execution(self, cmd, environment=None, workdir=None):
+        return self._run_and_check(cmd, True, environment=environment, workdir=workdir)
 
     def assert_unsuccessful_execution(self, cmd, environment=None):
-        return self._run_and_check(cmd, False, environment=environment)
+        return self._run_and_check(cmd, False, environment=environment,workdir=workdir)
 
     def install_python_module(self, name):
         if os.path.exists(name):
@@ -195,7 +195,10 @@ class UniversumRunner:
         return " -lo console -ad '{}'".format(self.artifact_dir)
 
     def _mandatory_args(self, config_file):
-        return " -pr '{}'  -lcp '{}'".format(self.project_root, config_file)
+        result = f" -lcp '{config_file}'"
+        if self.project_root:
+            result += f" -pr '{self.project_root}'"
+        return result
 
     def _vcs_args(self, vcs_type):
         if vcs_type == "none":
@@ -218,7 +221,7 @@ class UniversumRunner:
         return file_path
 
     def run(self, config: str, force_installed: bool = False, vcs_type: str = "none",
-            additional_parameters="", environment=None, expected_to_fail=False):
+            additional_parameters="", environment=None, expected_to_fail=False, workdir=None):
 
         if utils.is_pycharm():
             cmd = "{0}/universum/__main__.py".format(self.working_dir)
@@ -239,9 +242,9 @@ class UniversumRunner:
         cmd += self._mandatory_args(config_file) + ' ' + additional_parameters
 
         if expected_to_fail:
-            result = self.environment.assert_unsuccessful_execution(cmd, environment=environment)
+            result = self.environment.assert_unsuccessful_execution(cmd, environment=environment, workdir=workdir)
         else:
-            result = self.environment.assert_successful_execution(cmd, environment=environment)
+            result = self.environment.assert_successful_execution(cmd, environment=environment, workdir=workdir)
 
         os.remove(config_file)
         return result

--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -2,7 +2,7 @@ config = """
 from universum.configuration_support import Variations
 
 configs = Variations([dict(name="artifact check",
-                           command=["bash", "-c", '''cat /artifacts/test_nonci.txt''']),
+                           command=["bash", "-c", '''cat {}/artifacts/test_nonci.txt''']),
 #                                                    ^ this helps to check artifact is deleted before launch 
 
                       dict(name="test_step", artifacts="test_nonci.txt",
@@ -19,14 +19,17 @@ def test_launcher_output(docker_nonci):
      - sources are not copied to temp directory
      - artifacts are deleted before launching configs
      - version control and review system are not used
+     - project root is set to current directory
     """
-    file_output_expected = "Adding file /artifacts/test_step_log.txt to artifacts"
+    cwd = str(docker_nonci.working_dir)
+    file_output_expected = f"Adding file {cwd}/artifacts/test_step_log.txt to artifacts"
     pwd_string_in_logs = "pwd:[" + docker_nonci.local.root_directory.strpath + "]"
 
     docker_nonci.environment.assert_successful_execution(
-        "bash -c 'mkdir /artifacts; echo \"Old artifact\" > /artifacts/test_nonci.txt'")
+        f"bash -c 'mkdir {cwd}/artifacts; echo \"Old artifact\" > {cwd}/artifacts/test_nonci.txt'")
 
-    console_out_log = docker_nonci.run(config)
+    docker_nonci.project_root = None
+    console_out_log = docker_nonci.run(config.format(cwd), workdir=cwd)
 
     # the following logs are only present in the default mode of the universum
     assert file_output_expected not in console_out_log          # nonci doesn't write logs to the file by default
@@ -40,12 +43,12 @@ def test_launcher_output(docker_nonci):
     assert pwd_string_in_logs in console_out_log                # nonci launches step in the same directory
 
     # nonci doesn't require to clean artifacts between calls
-    log = docker_nonci.run(config, additional_parameters='-lo file')
+    log = docker_nonci.run(config.format(cwd), additional_parameters='-lo file', workdir=cwd)
     assert file_output_expected in log
 
     assert console_out_log != log
     step_log = docker_nonci.environment.assert_successful_execution(
-        "cat /artifacts/test_step_log.txt")
+        f"cat {cwd}/artifacts/test_step_log.txt")
     assert pwd_string_in_logs in step_log
 
     # second call of universum must not contain previous step log
@@ -54,10 +57,10 @@ from universum.configuration_support import Variations
 
 configs = Variations([dict(name="test_step",
                            command=["bash", "-c", '''echo "Separate run"'''])])
-""", additional_parameters='-lo file')
+""", additional_parameters='-lo file', workdir=cwd)
 
     second_run_step_log = docker_nonci.environment.assert_successful_execution(
-        "cat /artifacts/test_step_log.txt")
+        f"cat {cwd}/artifacts/test_step_log.txt")
     assert pwd_string_in_logs not in second_run_step_log
     assert "Separate run" in second_run_step_log
 

--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -21,9 +21,9 @@ def test_launcher_output(docker_nonci):
      - version control and review system are not used
      - project root is set to current directory
     """
-    cwd = str(docker_nonci.working_dir)
+    cwd = docker_nonci.local.root_directory.strpath
     file_output_expected = f"Adding file {cwd}/artifacts/test_step_log.txt to artifacts"
-    pwd_string_in_logs = "pwd:[" + docker_nonci.local.root_directory.strpath + "]"
+    pwd_string_in_logs = f"pwd:[{cwd}]"
 
     docker_nonci.environment.assert_successful_execution(
         f"bash -c 'mkdir {cwd}/artifacts; echo \"Old artifact\" > {cwd}/artifacts/test_nonci.txt'")

--- a/universum/__main__.py
+++ b/universum/__main__.py
@@ -7,7 +7,7 @@ from universum import __version__, __title__
 from universum.api import Api
 from universum.main import Main
 from universum.poll import Poll
-from universum.modules.launcher import Launcher
+from universum.nonci import Nonci
 from universum.submit import Submit
 from universum.lib.ci_exception import SilentAbortException
 from universum.lib.gravity import define_arguments_recursive, construct_component
@@ -33,7 +33,7 @@ def define_arguments():
     define_command(Api, "api")
     define_command(Poll, "poll")
     define_command(Submit, "submit")
-    define_command(Launcher, "nonci")
+    define_command(Nonci, "nonci")
 
     return parser
 

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -419,20 +419,4 @@ class Launcher(ProjectDirectory):
         self.reporter.add_block_to_report(self.structure.get_current_block())
         self.structure.execute_step_structure(self.project_configs, self.create_process)
 
-    def execute(self):
-        if not self.settings.output:
-            self.output = 'console'
 
-        self.out.log("Cleaning artifacts...")
-        self.artifacts.clean_artifacts_silently()
-
-        project_configs = self.process_project_configs()
-        self.artifacts.set_and_clean_artifacts(project_configs, ignore_existing_artifacts=True)
-
-        self.launch_project()
-        self.reporter.report_initialized = True
-        self.reporter.report_build_result()
-        self.artifacts.collect_artifacts()
-
-    def finalize(self):
-        pass

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -418,5 +418,3 @@ class Launcher(ProjectDirectory):
     def launch_project(self):
         self.reporter.add_block_to_report(self.structure.get_current_block())
         self.structure.execute_step_structure(self.project_configs, self.create_process)
-
-

--- a/universum/nonci.py
+++ b/universum/nonci.py
@@ -1,0 +1,32 @@
+import os
+
+from universum.modules.launcher import Launcher
+
+
+class Nonci(Launcher):
+
+    def __init__(self, *args, **kwargs):
+        # Patch settings before parent class is initialized
+        if not self.settings.output:
+            self.settings.output = 'console'
+
+        if not self.settings.project_root:
+            self.settings.project_root = os.getcwd()
+
+        super().__init__(*args, **kwargs)
+
+    def execute(self):
+
+        self.out.log("Cleaning artifacts...")
+        self.artifacts.clean_artifacts_silently()
+
+        project_configs = self.process_project_configs()
+        self.artifacts.set_and_clean_artifacts(project_configs, ignore_existing_artifacts=True)
+
+        self.launch_project()
+        self.reporter.report_initialized = True
+        self.reporter.report_build_result()
+        self.artifacts.collect_artifacts()
+
+    def finalize(self):
+        pass


### PR DESCRIPTION
By default in standard mode project root is set to 'temp'
subdirectory in current directory. But for nonci mode it
doesn't make sense. Implemented setting project root to
current directory if user does not specify this parameter.
