### PR TITLE
refactor(github_vcs): move non-mandatory import to __init__

### DIFF
--- a/doc/prerequisites.rst
+++ b/doc/prerequisites.rst
@@ -39,7 +39,8 @@ GitHub
 If used as GitHub Handler:
 
 * :mod:`pygithub` module for Python (use ``sudo pip install pygithub``)
-* :mod:`cffi` or :mod:`cryptography`
+* :mod:`cryptography` module for Python (use ``sudo pip install cryptography``), used by :mod:`pygithub` for
+  GitHub App token calculation
 
 If used as ``github`` VCS type, also includes `Git` requirements.
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ vcs = (
     'gitpython>=3.0.5',
     'p4python>=2019.1',
     'pygithub',
-    'cffi'  # TODO: check which of 'cryptography' or 'cffi' solves issue with 'github' better; also fix docs after
+    'cryptography'
 )
 
 setup(

--- a/universum/__main__.py
+++ b/universum/__main__.py
@@ -17,6 +17,7 @@ from universum.lib.utils import Uninterruptible, format_traceback
 
 
 def define_arguments():
+    # TODO: add 'prog', current usage '__main__.py' is quite misleading
     parser = ModuleArgumentParser(description=__title__ + " " + __version__)
     parser.add_argument("--version", action="version", version=__title__ + " " + __version__)
     define_arguments_recursive(Main, parser)

--- a/universum/modules/vcs/github_vcs.py
+++ b/universum/modules/vcs/github_vcs.py
@@ -7,7 +7,6 @@ import requests
 from ...lib.gravity import Dependency
 from ...lib import utils
 from ...lib.gravity import Module
-from ...lib.module_arguments import IncorrectParameterError
 from ..reporter import ReportObserver, Reporter
 from . import git_vcs
 
@@ -15,6 +14,8 @@ __all__ = [
     "GithubToken",
     "GithubMainVcs"
 ]
+
+github = None
 
 
 def get_time():
@@ -62,21 +63,20 @@ class GithubToken(Module):
                     Please note that `universum github-handler` DOES NOT pass private key to CI builds.
                 """)
 
-        self.token_issued = None
-        self._token = None
-
-    def _get_token(self, installation_id):
-        # TODO: move import to __init__()
-        variable = {"This",
-            "should trigger pylint warning"}
+        global github
         try:
             github = importlib.import_module("github")
         except ImportError:
             text = "Error: using GitHub Handler or VCS type 'github' requires Python package 'pygithub' " \
                    "to be installed to the system for correct GitHub App token processing. " \
+                   "It also requires Python package 'cryptography' to be installed in addition. " \
                    "Please refer to `Prerequisites` chapter of project documentation for detailed instructions"
             raise ImportError(text)
 
+        self.token_issued = None
+        self._token = None
+
+    def _get_token(self, installation_id):
         integration = github.GithubIntegration(self.settings.integration_id, self.key)
         auth_obj = integration.get_access_token(installation_id)
         return auth_obj.token

--- a/universum/modules/vcs/github_vcs.py
+++ b/universum/modules/vcs/github_vcs.py
@@ -67,6 +67,10 @@ class GithubToken(Module):
 
     def _get_token(self, installation_id):
         # TODO: move import to __init__()
+
+
+
+        # this should trigger pylint warning
         try:
             github = importlib.import_module("github")
         except ImportError:

--- a/universum/modules/vcs/github_vcs.py
+++ b/universum/modules/vcs/github_vcs.py
@@ -67,10 +67,8 @@ class GithubToken(Module):
 
     def _get_token(self, installation_id):
         # TODO: move import to __init__()
-
-
-
-        # this should trigger pylint warning
+        variable = {"This",
+            "should trigger pylint warning"}
         try:
             github = importlib.import_module("github")
         except ImportError:


### PR DESCRIPTION
Also specify vcs-related requirements in 'setup.py': package 'cryptography' has its own dependency on 'cffi', so installing 'cryptography' will also install 'cffi'. However, installing 'cffi' alone is not enough for correct module work.