### PR TITLE
fix: remove shebangs and absolute imports

### DIFF
--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -220,14 +220,13 @@ class UniversumRunner:
             f.write(config)
         return file_path
 
-    def run(self, config: str, vcs_type: str = "none", force_installed=False, workdir=None,
-            additional_parameters="", environment=None, expected_to_fail=False):
+    def run(self, config: str, force_installed: bool = False, vcs_type: str = "none",
+            additional_parameters="", environment=None, expected_to_fail=False, workdir=None):
 
-        # We can only collect coverage from local sources
         if force_installed:
             cmd = "python3.7 -I -m universum"
         elif utils.is_pycharm() or workdir:
-            # Changing workdir will also lead to using installed Universum instead of local sources
+            # Changing workdir may also lead to using installed Universum instead of local sources
             cmd = "python3.7 -m universum"
         else:
             cmd = f"coverage run --branch --append --source='{self.working_dir}' -m universum"

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -223,10 +223,16 @@ class UniversumRunner:
     def run(self, config: str, force_installed: bool = False, vcs_type: str = "none",
             additional_parameters="", environment=None, expected_to_fail=False, workdir=None):
 
-        # workdir is ignored unless force_installed;
-        # if installed to make sure local sources are not used by default the directory is changed
+        # as nonci changes workdir to project root, Universum is always an external moudule
+        # therefore for nonci it should always be installed to system
+        if self.nonci:
+            force_installed = True
+
+        # workdir is ignored unless force_installed is True
         if force_installed:
             if not workdir:
+                # when run from directory containing Universum sources, installed module will not be used
+                # therefore directory should be changed to any other to make sure 'python -m universum' still works
                 workdir = os.path.join(self.working_dir, "another_directory")
                 os.makedirs(workdir, exist_ok=True)
         else:

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -223,15 +223,20 @@ class UniversumRunner:
     def run(self, config: str, force_installed: bool = False, vcs_type: str = "none",
             additional_parameters="", environment=None, expected_to_fail=False, workdir=None):
 
-        if utils.is_pycharm():
-            cmd = "{0}/universum/__main__.py".format(self.working_dir)
-        else:
-            cmd = "coverage run --branch --append --source='{0}' '{0}/universum/__main__.py'" \
-                .format(self.working_dir)
-
-        # We cannot collect coverage from installed module, so we run it only if specifically told so
+        # workdir is ignored unless force_installed;
+        # if installed to make sure local sources are not used by default the directory is changed
         if force_installed:
+            if not workdir:
+                workdir = os.path.join(self.working_dir, "another_directory")
+                os.makedirs(workdir, exist_ok=True)
+        else:
+            workdir = self.working_dir
+
+        # We cannot collect coverage from installed module
+        if utils.is_pycharm() or force_installed:
             cmd = "python3.7 -m universum"
+        else:
+            cmd = f"coverage run --branch --append --source='.' 'python3.7 -m universum'"
 
         if self.nonci:
             cmd += ' nonci'

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -222,11 +222,17 @@ class UniversumRunner:
 
     def run(self, config: str, force_installed: bool = False, vcs_type: str = "none",
             additional_parameters="", environment=None, expected_to_fail=False, workdir=None):
+        """
+        `force_installed` launches python with '-I' option, that ensures the non-installed universum sources
+        will not be used instead of those installed into system. Without '-I' option `python3.7 -m` will first
+        try to launch universum from sources in `workdir` if there are any. That is why, if `workdir` is not
+        default and there are no universum sources in specified `workdir`, the preinstalled universum will
+        be ran as in case of `force_installed`.
+        """
 
         if force_installed:
             cmd = "python3.7 -I -m universum"
         elif utils.is_pycharm() or workdir:
-            # Changing workdir may also lead to using installed Universum instead of local sources
             cmd = "python3.7 -m universum"
         else:
             cmd = f"coverage run --branch --append --source='{self.working_dir}' -m universum"

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -236,7 +236,7 @@ class UniversumRunner:
         if utils.is_pycharm() or force_installed:
             cmd = "python3.7 -m universum"
         else:
-            cmd = f"coverage run --branch --append --source='.' 'python3.7 -m universum'"
+            cmd = f"coverage run --branch --append --source='{self.working_dir}' -m universum"
 
         if self.nonci:
             cmd += ' nonci'

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -223,8 +223,9 @@ class UniversumRunner:
     def run(self, config: str, force_installed: bool = False, vcs_type: str = "none",
             additional_parameters="", environment=None, expected_to_fail=False, workdir=None):
 
-        # as nonci changes workdir to project root, Universum is always an external moudule
-        # therefore for nonci it should always be installed to system
+        # 'python -m module_name' can only launch modules from current directory or already installed to the system
+        # but nonci changes workdir to project root (from current universum sources to sources to be checked by nonci)
+        # therefore to run Universum in nonci mode, it should always be installed to system
         if self.nonci:
             force_installed = True
 

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -220,27 +220,11 @@ class UniversumRunner:
             f.write(config)
         return file_path
 
-    def run(self, config: str, force_installed: bool = False, vcs_type: str = "none",
-            additional_parameters="", environment=None, expected_to_fail=False, workdir=None):
-
-        # 'python -m module_name' can only launch modules from current directory or already installed to the system
-        # but nonci changes workdir to project root (from current universum sources to sources to be checked by nonci)
-        # therefore to run Universum in nonci mode, it should always be installed to system
-        if self.nonci:
-            force_installed = True
-
-        # workdir is ignored unless force_installed is True
-        if force_installed:
-            if not workdir:
-                # when run from directory containing Universum sources, installed module will not be used
-                # therefore directory should be changed to any other to make sure 'python -m universum' still works
-                workdir = os.path.join(self.working_dir, "another_directory")
-                os.makedirs(workdir, exist_ok=True)
-        else:
-            workdir = self.working_dir
+    def run(self, config: str, vcs_type: str = "none", workdir=None,
+            additional_parameters="", environment=None, expected_to_fail=False):
 
         # We cannot collect coverage from installed module
-        if utils.is_pycharm() or force_installed:
+        if utils.is_pycharm() or workdir:
             cmd = "python3.7 -m universum"
         else:
             cmd = f"coverage run --branch --append --source='{self.working_dir}' -m universum"

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -220,11 +220,14 @@ class UniversumRunner:
             f.write(config)
         return file_path
 
-    def run(self, config: str, vcs_type: str = "none", workdir=None,
+    def run(self, config: str, vcs_type: str = "none", force_installed=False, workdir=None,
             additional_parameters="", environment=None, expected_to_fail=False):
 
-        # We cannot collect coverage from installed module
-        if utils.is_pycharm() or workdir:
+        # We can only collect coverage from local sources
+        if force_installed:
+            cmd = "python3.7 -I -m universum"
+        elif utils.is_pycharm() or workdir:
+            # Changing workdir will also lead to using installed Universum instead of local sources
             cmd = "python3.7 -m universum"
         else:
             cmd = f"coverage run --branch --append --source='{self.working_dir}' -m universum"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,8 +1,3 @@
-import os
-
-from .utils import randomize_name
-
-
 config = """
 from universum.configuration_support import Variations
 
@@ -11,66 +6,45 @@ configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
 
 
 def test_minimal_install(clean_docker_main):
-    # Create tmpdir in container to make sure local universum sources are not used instead of installed
-    tmpdir = os.path.join(clean_docker_main.working_dir, randomize_name('tmpdir'))
-    clean_docker_main.environment.assert_successful_execution(f"mkdir '{tmpdir}'")
-
     # Run without parameters
     log = clean_docker_main.environment.assert_unsuccessful_execution("python3.7 -m universum")
     assert "No module named universum" not in log
 
     # Run locally
-    log = clean_docker_main.run(config, workdir=tmpdir)
+    log = clean_docker_main.run(config, force_installed=True)
     assert clean_docker_main.local.repo_file.basename in log
 
     # Run from Git
     clean_docker_main.clean_artifacts()
-    log = clean_docker_main.run(config, vcs_type="git", workdir=tmpdir)
+    log = clean_docker_main.run(config, vcs_type="git", force_installed=True)
     assert clean_docker_main.git.repo_file.basename in log
 
     # Run from P4
     clean_docker_main.clean_artifacts()
-    log = clean_docker_main.run(config, vcs_type="p4", workdir=tmpdir)
+    log = clean_docker_main.run(config, vcs_type="p4", force_installed=True)
     assert clean_docker_main.perforce.repo_file.basename in log
-
-    # Clean
-    clean_docker_main.environment.assert_successful_execution(f"rm -rf '{tmpdir}'")
 
 
 def test_minimal_install_with_git_only(clean_docker_main_no_p4, capsys):
-    # Create tmpdir in container to make sure local universum sources are not used instead of installed
-    tmpdir = os.path.join(clean_docker_main_no_p4.working_dir, randomize_name('tmpdir'))
-    clean_docker_main_no_p4.environment.assert_successful_execution(f"mkdir '{tmpdir}'")
-
     # Run from P4
-    clean_docker_main_no_p4.run(config, vcs_type="p4", workdir=tmpdir, expected_to_fail=True)
+    clean_docker_main_no_p4.run(config, vcs_type="p4", force_installed=True, expected_to_fail=True)
     assert "Please refer to `Prerequisites` chapter of project documentation" in capsys.readouterr().out
 
     # Run from git
     clean_docker_main_no_p4.clean_artifacts()
-    log = clean_docker_main_no_p4.run(config, vcs_type="git", workdir=tmpdir)
+    log = clean_docker_main_no_p4.run(config, vcs_type="git", force_installed=True)
     assert clean_docker_main_no_p4.git.repo_file.basename in log
-
-    # Clean
-    clean_docker_main_no_p4.environment.assert_successful_execution(f"rm -rf '{tmpdir}'")
 
 
 def test_minimal_install_plain_ubuntu(clean_docker_main_no_vcs, capsys):
-    # Create tmpdir in container to make sure local universum sources are not used instead of installed
-    tmpdir = os.path.join(clean_docker_main_no_vcs.working_dir, randomize_name('tmpdir'))
-    clean_docker_main_no_vcs.environment.assert_successful_execution(f"mkdir '{tmpdir}'")
-
     # Run from P4
-    clean_docker_main_no_vcs.run(config, vcs_type="p4", workdir=tmpdir, expected_to_fail=True)
+    clean_docker_main_no_vcs.run(config, vcs_type="p4", force_installed=True, expected_to_fail=True)
     assert "Please refer to `Prerequisites` chapter of project documentation" in capsys.readouterr().out
 
     # Run from Git
-    clean_docker_main_no_vcs.run(config, vcs_type="git", workdir=tmpdir, expected_to_fail=True)
+    clean_docker_main_no_vcs.run(config, vcs_type="git", force_installed=True, expected_to_fail=True)
     assert "Please refer to `Prerequisites` chapter of project documentation" in capsys.readouterr().out
 
     # Run locally
-    log = clean_docker_main_no_vcs.run(config, workdir=tmpdir)
+    log = clean_docker_main_no_vcs.run(config, force_installed=True)
     assert clean_docker_main_no_vcs.local.repo_file.basename in log
-
-    # Clean
-    clean_docker_main_no_vcs.environment.assert_successful_execution(f"rm -rf '{tmpdir}'")

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -13,7 +13,7 @@ configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
 def test_minimal_install(clean_docker_main):
     # Create tmpdir in container to make sure local universum sources are not used instead of installed
     tmpdir = os.path.join(clean_docker_main.working_dir, randomize_name('tmpdir'))
-    clean_docker_main.environment.assert_successful_execution(f"mkdir {tmpdir}")
+    clean_docker_main.environment.assert_successful_execution(f"mkdir '{tmpdir}'")
 
     # Run without parameters
     log = clean_docker_main.environment.assert_unsuccessful_execution("python3.7 -m universum")
@@ -34,13 +34,13 @@ def test_minimal_install(clean_docker_main):
     assert clean_docker_main.perforce.repo_file.basename in log
 
     # Clean
-    clean_docker_main.environment.assert_successful_execution(f"rm -rf {tmpdir}")
+    clean_docker_main.environment.assert_successful_execution(f"rm -rf '{tmpdir}'")
 
 
 def test_minimal_install_with_git_only(clean_docker_main_no_p4, capsys):
     # Create tmpdir in container to make sure local universum sources are not used instead of installed
     tmpdir = os.path.join(clean_docker_main_no_p4.working_dir, randomize_name('tmpdir'))
-    clean_docker_main_no_p4.environment.assert_successful_execution(f"mkdir {tmpdir}")
+    clean_docker_main_no_p4.environment.assert_successful_execution(f"mkdir '{tmpdir}'")
 
     # Run from P4
     clean_docker_main_no_p4.run(config, vcs_type="p4", workdir=tmpdir, expected_to_fail=True)
@@ -52,13 +52,13 @@ def test_minimal_install_with_git_only(clean_docker_main_no_p4, capsys):
     assert clean_docker_main_no_p4.git.repo_file.basename in log
 
     # Clean
-    clean_docker_main_no_p4.environment.assert_successful_execution(f"rm -rf {tmpdir}")
+    clean_docker_main_no_p4.environment.assert_successful_execution(f"rm -rf '{tmpdir}'")
 
 
 def test_minimal_install_plain_ubuntu(clean_docker_main_no_vcs, capsys):
     # Create tmpdir in container to make sure local universum sources are not used instead of installed
     tmpdir = os.path.join(clean_docker_main_no_vcs.working_dir, randomize_name('tmpdir'))
-    clean_docker_main_no_vcs.environment.assert_successful_execution(f"mkdir {tmpdir}")
+    clean_docker_main_no_vcs.environment.assert_successful_execution(f"mkdir '{tmpdir}'")
 
     # Run from P4
     clean_docker_main_no_vcs.run(config, vcs_type="p4", workdir=tmpdir, expected_to_fail=True)
@@ -73,4 +73,4 @@ def test_minimal_install_plain_ubuntu(clean_docker_main_no_vcs, capsys):
     assert clean_docker_main_no_vcs.local.repo_file.basename in log
 
     # Clean
-    clean_docker_main_no_vcs.environment.assert_successful_execution(f"rm -rf {tmpdir}")
+    clean_docker_main_no_vcs.environment.assert_successful_execution(f"rm -rf '{tmpdir}'")

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,3 +1,8 @@
+import os
+
+from .utils import randomize_name
+
+
 config = """
 from universum.configuration_support import Variations
 
@@ -6,45 +11,66 @@ configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
 
 
 def test_minimal_install(clean_docker_main):
+    # Create tmpdir in container to make sure local universum sources are not used instead of installed
+    tmpdir = os.path.join(clean_docker_main.working_dir, randomize_name('tmpdir'))
+    clean_docker_main.environment.assert_successful_execution(f"mkdir {tmpdir}")
+
     # Run without parameters
-    log = clean_docker_main.environment.assert_unsuccessful_execution("universum")
-    assert "command not found" not in log
+    log = clean_docker_main.environment.assert_unsuccessful_execution("python3.7 -m universum")
+    assert "No module named universum" not in log
 
     # Run locally
-    log = clean_docker_main.run(config, force_installed=True)
+    log = clean_docker_main.run(config, workdir=tmpdir)
     assert clean_docker_main.local.repo_file.basename in log
 
     # Run from Git
     clean_docker_main.clean_artifacts()
-    log = clean_docker_main.run(config, vcs_type="git", force_installed=True)
+    log = clean_docker_main.run(config, vcs_type="git", workdir=tmpdir)
     assert clean_docker_main.git.repo_file.basename in log
 
     # Run from P4
     clean_docker_main.clean_artifacts()
-    log = clean_docker_main.run(config, vcs_type="p4", force_installed=True)
+    log = clean_docker_main.run(config, vcs_type="p4", workdir=tmpdir)
     assert clean_docker_main.perforce.repo_file.basename in log
+
+    # Clean
+    clean_docker_main.environment.assert_successful_execution(f"rm -rf {tmpdir}")
 
 
 def test_minimal_install_with_git_only(clean_docker_main_no_p4, capsys):
+    # Create tmpdir in container to make sure local universum sources are not used instead of installed
+    tmpdir = os.path.join(clean_docker_main_no_p4.working_dir, randomize_name('tmpdir'))
+    clean_docker_main_no_p4.environment.assert_successful_execution(f"mkdir {tmpdir}")
+
     # Run from P4
-    clean_docker_main_no_p4.run(config, vcs_type="p4", force_installed=True, expected_to_fail=True)
+    clean_docker_main_no_p4.run(config, vcs_type="p4", workdir=tmpdir, expected_to_fail=True)
     assert "Please refer to `Prerequisites` chapter of project documentation" in capsys.readouterr().out
 
     # Run from git
     clean_docker_main_no_p4.clean_artifacts()
-    log = clean_docker_main_no_p4.run(config, vcs_type="git", force_installed=True)
+    log = clean_docker_main_no_p4.run(config, vcs_type="git", workdir=tmpdir)
     assert clean_docker_main_no_p4.git.repo_file.basename in log
+
+    # Clean
+    clean_docker_main_no_p4.environment.assert_successful_execution(f"rm -rf {tmpdir}")
 
 
 def test_minimal_install_plain_ubuntu(clean_docker_main_no_vcs, capsys):
+    # Create tmpdir in container to make sure local universum sources are not used instead of installed
+    tmpdir = os.path.join(clean_docker_main_no_vcs.working_dir, randomize_name('tmpdir'))
+    clean_docker_main_no_vcs.environment.assert_successful_execution(f"mkdir {tmpdir}")
+
     # Run from P4
-    clean_docker_main_no_vcs.run(config, vcs_type="p4", force_installed=True, expected_to_fail=True)
+    clean_docker_main_no_vcs.run(config, vcs_type="p4", workdir=tmpdir, expected_to_fail=True)
     assert "Please refer to `Prerequisites` chapter of project documentation" in capsys.readouterr().out
 
     # Run from Git
-    clean_docker_main_no_vcs.run(config, vcs_type="git", force_installed=True, expected_to_fail=True)
+    clean_docker_main_no_vcs.run(config, vcs_type="git", workdir=tmpdir, expected_to_fail=True)
     assert "Please refer to `Prerequisites` chapter of project documentation" in capsys.readouterr().out
 
     # Run locally
-    log = clean_docker_main_no_vcs.run(config, force_installed=True)
+    log = clean_docker_main_no_vcs.run(config, workdir=tmpdir)
     assert clean_docker_main_no_vcs.local.repo_file.basename in log
+
+    # Clean
+    clean_docker_main_no_vcs.environment.assert_successful_execution(f"rm -rf {tmpdir}")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -77,7 +77,7 @@ from universum.configuration_support import Variations
 configs = Variations([dict(name="Bad step", command=["ls", "not_a_file"]),
                       dict(name="Good bg step", command=["touch", "file"],
                       background=True, artifacts="file")])
-""")
+""", force_installed=docker_main_and_nonci.nonci)
     assert "All ongoing background steps completed" in log
     artifacts_must_collect = not docker_main_and_nonci.nonci
     assert artifacts_must_collect == os.path.exists(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -77,7 +77,7 @@ from universum.configuration_support import Variations
 configs = Variations([dict(name="Bad step", command=["ls", "not_a_file"]),
                       dict(name="Good bg step", command=["touch", "file"],
                       background=True, artifacts="file")])
-""", force_installed=docker_main_and_nonci.nonci)
+""")
     assert "All ongoing background steps completed" in log
     artifacts_must_collect = not docker_main_and_nonci.nonci
     assert artifacts_must_collect == os.path.exists(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -331,7 +331,7 @@ configs = Variations([dict(name="Long step", command=["sleep", "10"])]) * 5
     config_file = tmpdir.join("configs.py")
     config_file.write(config)
 
-    process = subprocess.Popen(["python3.7", os.path.join(os.getcwd(), "universum", "__main__.py"),
+    process = subprocess.Popen(["python3.7", "-m", "universum",
                                 "-o", "console", "-vt", "none",
                                 "-pr", str(tmpdir.join("project_root")),
                                 "-ad", str(tmpdir.join("artifacts")),

--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -19,7 +19,8 @@ def test_launcher_output(docker_nonci):
      - sources are not copied to temp directory
      - artifacts are deleted before launching configs
      - version control and review system are not used
-     - project root is set to current directory
+     - project root is set to current directory;
+       as we mess with the workdir, universum should be installed to work correctly
     """
     cwd = docker_nonci.local.root_directory.strpath
     file_output_expected = f"Adding file {cwd}/artifacts/test_step_log.txt to artifacts"
@@ -29,7 +30,7 @@ def test_launcher_output(docker_nonci):
         f"bash -c 'mkdir {cwd}/artifacts; echo \"Old artifact\" > {cwd}/artifacts/test_nonci.txt'")
 
     docker_nonci.project_root = None
-    console_out_log = docker_nonci.run(config.format(cwd), workdir=cwd)
+    console_out_log = docker_nonci.run(config.format(cwd), workdir=cwd, force_installed=True)
 
     # the following logs are only present in the default mode of the universum
     assert file_output_expected not in console_out_log          # nonci doesn't write logs to the file by default
@@ -43,7 +44,7 @@ def test_launcher_output(docker_nonci):
     assert pwd_string_in_logs in console_out_log                # nonci launches step in the same directory
 
     # nonci doesn't require to clean artifacts between calls
-    log = docker_nonci.run(config.format(cwd), additional_parameters='-lo file', workdir=cwd)
+    log = docker_nonci.run(config.format(cwd), additional_parameters='-lo file', workdir=cwd, force_installed=True)
     assert file_output_expected in log
 
     assert console_out_log != log
@@ -57,7 +58,7 @@ from universum.configuration_support import Variations
 
 configs = Variations([dict(name="test_step",
                            command=["bash", "-c", '''echo "Separate run"'''])])
-""", additional_parameters='-lo file', workdir=cwd)
+""", additional_parameters='-lo file', workdir=cwd, force_installed=True)
 
     second_run_step_log = docker_nonci.environment.assert_successful_execution(
         f"cat {cwd}/artifacts/test_step_log.txt")

--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -19,8 +19,7 @@ def test_launcher_output(docker_nonci):
      - sources are not copied to temp directory
      - artifacts are deleted before launching configs
      - version control and review system are not used
-     - project root is set to current directory;
-       as we mess with the workdir, universum should be installed to work correctly
+     - project root is set to current directory
     """
     cwd = docker_nonci.local.root_directory.strpath
     file_output_expected = f"Adding file {cwd}/artifacts/test_step_log.txt to artifacts"
@@ -30,7 +29,7 @@ def test_launcher_output(docker_nonci):
         f"bash -c 'mkdir {cwd}/artifacts; echo \"Old artifact\" > {cwd}/artifacts/test_nonci.txt'")
 
     docker_nonci.project_root = None
-    console_out_log = docker_nonci.run(config.format(cwd), workdir=cwd, force_installed=True)
+    console_out_log = docker_nonci.run(config.format(cwd), workdir=cwd)
 
     # the following logs are only present in the default mode of the universum
     assert file_output_expected not in console_out_log          # nonci doesn't write logs to the file by default
@@ -44,7 +43,7 @@ def test_launcher_output(docker_nonci):
     assert pwd_string_in_logs in console_out_log                # nonci launches step in the same directory
 
     # nonci doesn't require to clean artifacts between calls
-    log = docker_nonci.run(config.format(cwd), additional_parameters='-lo file', workdir=cwd, force_installed=True)
+    log = docker_nonci.run(config.format(cwd), additional_parameters='-lo file', workdir=cwd)
     assert file_output_expected in log
 
     assert console_out_log != log
@@ -58,7 +57,7 @@ from universum.configuration_support import Variations
 
 configs = Variations([dict(name="test_step",
                            command=["bash", "-c", '''echo "Separate run"'''])])
-""", additional_parameters='-lo file', workdir=cwd, force_installed=True)
+""", additional_parameters='-lo file', workdir=cwd)
 
     second_run_step_log = docker_nonci.environment.assert_successful_execution(
         f"cat {cwd}/artifacts/test_step_log.txt")

--- a/universum/__main__.py
+++ b/universum/__main__.py
@@ -1,19 +1,17 @@
-#!/usr/bin/env python3.7
-
 import signal
 import sys
 
-from universum import __version__, __title__
-from universum.api import Api
-from universum.main import Main
-from universum.github_handler import GithubHandler
-from universum.nonci import Nonci
-from universum.poll import Poll
-from universum.submit import Submit
-from universum.lib.ci_exception import SilentAbortException
-from universum.lib.gravity import define_arguments_recursive, construct_component
-from universum.lib.module_arguments import ModuleArgumentParser, IncorrectParameterError
-from universum.lib.utils import Uninterruptible, format_traceback
+from . import __version__, __title__
+from .api import Api
+from .main import Main
+from .github_handler import GithubHandler
+from .nonci import Nonci
+from .poll import Poll
+from .submit import Submit
+from .lib.ci_exception import SilentAbortException
+from .lib.gravity import define_arguments_recursive, construct_component
+from .lib.module_arguments import ModuleArgumentParser, IncorrectParameterError
+from .lib.utils import Uninterruptible, format_traceback
 
 
 def define_arguments():

--- a/universum/analyzers/pylint.py
+++ b/universum/analyzers/pylint.py
@@ -3,9 +3,8 @@ import glob
 import json
 import sys
 import subprocess
-import os
 
-from universum.analyzers import utils
+from . import utils
 
 
 class PylintAnalyzer:

--- a/universum/analyzers/uncrustify.py
+++ b/universum/analyzers/uncrustify.py
@@ -5,7 +5,6 @@ import os
 
 import re
 import sh
-from six.moves import zip
 
 from . import utils
 
@@ -15,8 +14,7 @@ MAX_LINES = 11
 
 
 def replace_invisible_symbols(line):
-    for old_str, new_str in zip([u" ", u"\t", u"\n"],
-                                [u"\u00b7", u"\u2192\u2192\u2192\u2192", u"\u2193\u000a"]):
+    for old_str, new_str in zip([u" ", u"\t", u"\n"], [u"\u00b7", u"\u2192\u2192\u2192\u2192", u"\u2193\u000a"]):
         return line.replace(old_str, new_str)
 
 


### PR DESCRIPTION
Resolves #214 as no longer applicable

We remove shebangs as Universum is no longer recommended to be run as a script (as in `./universum/__main__.py`).
Recommended way instead is running it via `python3.7 -m universum`, to fix the entry point issues (such as not being able to pass exit codes), and also to make used python version clear to user.

We replace absolute imports with relative as they were only needed for script launching to work, and caused a very non-obvious scenario for developing, when a main module launched locally imported installed version of `universum` folder instead of local (and presumably changed) one.