### PR TITLE
fix(structure_handler, git_vcs, vcs): pre-existing mypy errors

### DIFF
--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -4,7 +4,7 @@ from .. import configuration_support
 from ..lib.ci_exception import SilentAbortException, StepException, CriticalCiException
 from ..lib.gravity import Module, Dependency
 from .output import needs_output
-
+from typing import List, Optional
 __all__ = [
     "needs_structure"
 ]
@@ -51,15 +51,15 @@ class Block:
     True
     """
 
-    def __init__(self, name: str, parent: 'Block' = None):
-        self.name = name
-        self.status = "Success"
-        self.children = []
+    def __init__(self, name: str, parent: Optional[Block] = None):
+        self.name: str = name
+        self.status: str = "Success"
+        self.children: List[Block] = []
 
-        self._parent = parent
-        self.number = ''
-        if self.parent:
-            self.parent.children.append(self)
+        self._parent: Optional[Block] = parent
+        self.number: str = ''
+        if parent:
+            parent.children.append(self)
             self.number = '{}{}.'.format(parent.number, len(parent.children))
 
     def __str__(self) -> str:
@@ -67,7 +67,7 @@ class Block:
         return '{} - {}'.format(result, self.status) if not self.children else result
 
     @property  # getter
-    def parent(self) -> 'Block':
+    def parent(self) -> Optional[Block]:
         return self._parent
 
     def is_successful(self) -> bool:
@@ -78,11 +78,10 @@ class Block:
 class StructureHandler(Module):
     def __init__(self, *args, **kwargs):
         super(StructureHandler, self).__init__(*args, **kwargs)
-        block_structure = Block("Universum")
-        self.current_block = block_structure
-        self.configs_current_number = 0
-        self.configs_total_count = 0
-        self.active_background_steps = []
+        self.current_block: Block = Block("Universum")
+        self.configs_current_number: int = 0
+        self.configs_total_count: int = 0
+        self.active_background_steps: List[Callable[[Any], Any]] = []
 
     def open_block(self, name):
         new_block = Block(name, self.current_block)

--- a/universum/modules/vcs/git_vcs.py
+++ b/universum/modules/vcs/git_vcs.py
@@ -2,7 +2,7 @@ import glob
 import importlib
 import os
 
-from .base_vcs import BaseVcs, BaseDownloadVcs
+from .base_vcs import BaseVcs, BaseDownloadVcs, BasePollVcs, BaseSubmitVcs
 from ..output import needs_output
 from ..structure_handler import needs_structure
 from ...lib import utils
@@ -196,7 +196,7 @@ class GitMainVcs(GitVcs, BaseDownloadVcs):
 
 
 @needs_output
-class GitSubmitVcs(GitVcs):
+class GitSubmitVcs(GitVcs, BaseSubmitVcs):
     @staticmethod
     def define_arguments(argument_parser):
         parser = argument_parser.get_or_create_group("Git")
@@ -304,7 +304,7 @@ class GitSubmitVcs(GitVcs):
         return change
 
 
-class GitPollVcs(GitVcs):
+class GitPollVcs(GitVcs, BasePollVcs):
     def get_changes(self, changes_reference=None, max_number='1'):
         self.clone_and_fetch()
         if not changes_reference:

--- a/universum/modules/vcs/vcs.py
+++ b/universum/modules/vcs/vcs.py
@@ -3,6 +3,8 @@ import json
 import shutil
 import sh
 
+from typing import cast, Dict, List, Type, Union
+
 from . import git_vcs, github_vcs, gerrit_vcs, perforce_vcs, local_vcs, base_vcs
 from .. import artifact_collector
 from ..api_support import ApiSupport
@@ -20,35 +22,43 @@ __all__ = [
 ]
 
 
-def create_vcs(class_type=None):
+def create_vcs(class_type: str = None) -> Type[ProjectDirectory]:
+    driver_factory_class: Union[
+        Dict[str, Type[base_vcs.BasePollVcs]],
+        Dict[str, Type[base_vcs.BaseSubmitVcs]],
+        Dict[str, Type[base_vcs.BaseDownloadVcs]]
+    ]
     if class_type == "submit":
-        p4_driver_factory_class = perforce_vcs.PerforceSubmitVcs
-        git_driver_factory_class = git_vcs.GitSubmitVcs
-        gerrit_driver_factory_class = gerrit_vcs.GerritSubmitVcs
-        github_driver_factory_class = git_vcs.GitSubmitVcs
-        local_driver_factory_class = base_vcs.BaseSubmitVcs
+        driver_factory_class = {
+            "none" : base_vcs.BaseSubmitVcs,
+            "p4" : perforce_vcs.PerforceSubmitVcs,
+            "git" : git_vcs.GitSubmitVcs,
+            "gerrit" : gerrit_vcs.GerritSubmitVcs,
+            "github" : git_vcs.GitSubmitVcs
+        }
     elif class_type == "poll":
-        p4_driver_factory_class = perforce_vcs.PerforcePollVcs
-        git_driver_factory_class = git_vcs.GitPollVcs
-        gerrit_driver_factory_class = git_vcs.GitPollVcs
-        github_driver_factory_class = git_vcs.GitPollVcs
-        local_driver_factory_class = base_vcs.BasePollVcs
+        driver_factory_class = {
+            "none": base_vcs.BasePollVcs,
+            "p4": perforce_vcs.PerforcePollVcs,
+            "git": git_vcs.GitPollVcs,
+            "gerrit": git_vcs.GitPollVcs,
+            "github": git_vcs.GitPollVcs
+        }
     else:
-        p4_driver_factory_class = perforce_vcs.PerforceMainVcs
-        git_driver_factory_class = git_vcs.GitMainVcs
-        gerrit_driver_factory_class = gerrit_vcs.GerritMainVcs
-        github_driver_factory_class = github_vcs.GithubMainVcs
-        local_driver_factory_class = local_vcs.LocalMainVcs
+        driver_factory_class = {
+            "none": local_vcs.LocalMainVcs,
+            "p4": perforce_vcs.PerforceMainVcs,
+            "git": git_vcs.GitMainVcs,
+            "gerrit": gerrit_vcs.GerritMainVcs,
+            "github": github_vcs.GithubMainVcs
+        }
 
-    vcs_types = ["none", "p4", "git", "gerrit", "github"]
+    vcs_types: List[str] = ["none", "p4", "git", "gerrit", "github"]
 
     @needs_structure
     class Vcs(ProjectDirectory):
-        local_driver_factory = Dependency(local_driver_factory_class)
-        git_driver_factory = Dependency(git_driver_factory_class)
-        gerrit_driver_factory = Dependency(gerrit_driver_factory_class)
-        github_driver_factory = Dependency(github_driver_factory_class)
-        perforce_driver_factory = Dependency(p4_driver_factory_class)
+        driver_factory: Dict[str, Dependency] = {vcs_type: Dependency(cls)
+                                                       for vcs_type, cls in driver_factory_class.items()}
 
         @staticmethod
         def define_arguments(argument_parser):
@@ -87,19 +97,9 @@ def create_vcs(class_type=None):
                 raise IncorrectParameterError(text)
 
             try:
-                if self.settings.type == "none":
-                    driver_factory = self.local_driver_factory
-                elif self.settings.type == "git":
-                    driver_factory = self.git_driver_factory
-                elif self.settings.type == "gerrit":
-                    driver_factory = self.gerrit_driver_factory
-                elif self.settings.type == "github":
-                    driver_factory = self.github_driver_factory
-                else:
-                    driver_factory = self.perforce_driver_factory
-            except AttributeError:
+                self.driver = driver_factory[self.settings.type]()
+            except AttributeError | KeyError:
                 raise NotImplementedError()
-            self.driver = driver_factory()
 
         @make_block("Finalizing")
         def finalize(self):
@@ -108,11 +108,11 @@ def create_vcs(class_type=None):
     return Vcs
 
 
-PollVcs = create_vcs("poll")
-SubmitVcs = create_vcs("submit")
+PollVcs: Type[ProjectDirectory] = create_vcs("poll")
+SubmitVcs: Type[ProjectDirectory] = create_vcs("submit")
 
 
-class MainVcs(create_vcs()):
+class MainVcs(create_vcs()):  # type: ignore  # https://github.com/python/mypy/issues/2477
     artifacts_factory = Dependency(artifact_collector.ArtifactCollector)
     api_support_factory = Dependency(ApiSupport)
 


### PR DESCRIPTION
Related to https://github.com/Samsung/Universum/issues/273

Without the fix, checking 'main' using mypy generates some errors. With the fix the only remaining errors are due to lack of static type annotations in the dependencies (third-party libraries).
To make static analysis of 'vcs' module meaningful, some minor refactoring was needed.
Also, added static type annotations highlighted some missing dependencies in 'git_vcs'.

!!! Please note that no tests have been run yet - this is preliminary pull request for some early feedback.

# Checklist:

- [ ] My code follows the [PEP 8](https://www.python.org/dev/peps/pep-0008/)
- [ ✓ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
