### PR TITLE
fix(tests): multiple minor issues with pytest and PyCharm

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -331,7 +331,7 @@ configs = Variations([dict(name="Long step", command=["sleep", "10"])]) * 5
     config_file = tmpdir.join("configs.py")
     config_file.write(config)
 
-    process = subprocess.Popen(["python3.7", os.path.join(os.getcwd(), "universum", "__main__.py"),
+    process = subprocess.Popen(["python3.7", "-m", "universum",
                                 "-o", "console", "-vt", "none",
                                 "-pr", str(tmpdir.join("project_root")),
                                 "-ad", str(tmpdir.join("artifacts")),

--- a/universum/lib/utils.py
+++ b/universum/lib/utils.py
@@ -100,7 +100,7 @@ def read_and_check_multiline_option(settings, setting_name, error_message):
             except FileNotFoundError as e:
                 raise IncorrectParameterError(f"Error reading argument {setting_name} from file {e.filename}: no such file")
         elif value == '-':
-            result = sys.stdin.read()
+            result = "".join(sys.stdin.readlines())
         else:
             result = value
     except AttributeError:


### PR DESCRIPTION
1. test_abort and test_multiline failed if Universum is not installed
    * Added PYTHONPATH environment variable to multiline test and fixed
      python command line for abort test

2. "-s" option of the pytest led to the hang up of third invocation of
   the test script in the multiline test
    * Explicitly provided empty input in the third invocation

3. multiline test failed in PyCharm
    * Known bug (https://youtrack.jetbrains.com/issue/PY-40035)
    * Implemented workaround by changing sys.stdin.read() to
      sys.stdin.readlines()