### PR TITLE
refactor: add type annotations to gravity module

### DIFF
--- a/configs.py
+++ b/configs.py
@@ -32,7 +32,7 @@ configs = Variations([dict(name="Update Docker images", command=["make", "images
                                     "--rcfile=pylintrc", "--result-file=${CODE_REPORT_FILE}",
                                     "--files", "*.py", "universum/", "tests/"]),
                       dict(name="Run static type checker", code_report=True,
-                           command=["python3.7", "-m", "mypy", "universum/__main__.py", "--ignore-missing-imports"]),
+                           command=["python3.7", "-m", "mypy", "universum/", "--ignore-missing-imports"]),
 
                       dict(name="Run Jenkins plugin Java tests",
                            artifacts="universum_log_collapser/universum_log_collapser/target/surefire-reports/*.xml",

--- a/configs.py
+++ b/configs.py
@@ -31,6 +31,8 @@ configs = Variations([dict(name="Update Docker images", command=["make", "images
                            command=["python3.7", "-m", "universum.analyzers.pylint", "--python-version=3.7",
                                     "--rcfile=pylintrc", "--result-file=${CODE_REPORT_FILE}",
                                     "--files", "*.py", "universum/", "tests/"]),
+                      dict(name="Run static type checker", code_report=True,
+                           command=["python3.7", "-m", "mypy", "universum/main.py"]),
 
                       dict(name="Run Jenkins plugin Java tests",
                            artifacts="universum_log_collapser/universum_log_collapser/target/surefire-reports/*.xml",

--- a/configs.py
+++ b/configs.py
@@ -32,7 +32,7 @@ configs = Variations([dict(name="Update Docker images", command=["make", "images
                                     "--rcfile=pylintrc", "--result-file=${CODE_REPORT_FILE}",
                                     "--files", "*.py", "universum/", "tests/"]),
                       dict(name="Run static type checker", code_report=True,
-                           command=["python3.7", "-m", "mypy", "universum/main.py", "--ignore-missing-imports"]),
+                           command=["python3.7", "-m", "mypy", "universum/__main__.py", "--ignore-missing-imports"]),
 
                       dict(name="Run Jenkins plugin Java tests",
                            artifacts="universum_log_collapser/universum_log_collapser/target/surefire-reports/*.xml",

--- a/configs.py
+++ b/configs.py
@@ -32,7 +32,7 @@ configs = Variations([dict(name="Update Docker images", command=["make", "images
                                     "--rcfile=pylintrc", "--result-file=${CODE_REPORT_FILE}",
                                     "--files", "*.py", "universum/", "tests/"]),
                       dict(name="Run static type checker", code_report=True,
-                           command=["python3.7", "-m", "mypy", "universum/main.py"]),
+                           command=["python3.7", "-m", "mypy", "universum/main.py", "--ignore-missing-imports"]),
 
                       dict(name="Run Jenkins plugin Java tests",
                            artifacts="universum_log_collapser/universum_log_collapser/target/surefire-reports/*.xml",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
         'requests',
         'sh',
         'lxml',
-        'six'
+        'six',
+        'typing-extensions'
     ],
     extras_require={
         'docs': [docs],

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -1,5 +1,5 @@
 from typing import cast, Any, Callable, ClassVar, Dict, Generic, List, Optional, Type, TypeVar, TYPE_CHECKING, Union
-
+from typing_extensions import Protocol
 __all__ = [
     "Module",
     "Dependency",
@@ -51,8 +51,9 @@ class Settings:
         setattr(obj.main_settings, self.cls.__name__, settings)
 
 
-class HasModulesMapping:
+class HasModulesMapping(Protocol):
     active_modules: Dict[Type['Module'], 'Module']
+
 
 class Module:
     settings: ClassVar['Settings']

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -1,4 +1,4 @@
-from typing import cast, Any, Callable, ClassVar, Dict, Generic, List, NoReturn, Optional, Type, TypeVar, Union
+from typing import cast, Any, Callable, ClassVar, Dict, Generic, List, Optional, Type, TypeVar, Union
 
 __all__ = [
     "Module",
@@ -12,7 +12,6 @@ class ModuleSettings:
     def __init__(self, cls: Type['Module'], main_settings: 'ModuleSettings') -> None:
         object.__setattr__(self, "cls", cls)
         object.__setattr__(self, "main_settings", main_settings)
-        # TODO: can't clarify that active_modules[Type[X]] returns X (https://github.com/python/mypy/issues/4928)
         self.active_modules: Dict[Type[Module], Module]
 
     def __getattribute__(self, item: str) -> Union[str, List[str]]:
@@ -53,16 +52,18 @@ class Settings:
         setattr(obj.main_settings, self.cls.__name__, settings)
 
 
-class Module():
+class Module:
     settings: ClassVar['Settings']
     main_settings: 'ModuleSettings'
+
     def __new__(cls: Type['Module'], main_settings: 'ModuleSettings', *args, **kwargs) -> 'Module':
         instance: Module = super(Module, cls).__new__(cls)
         instance.main_settings = main_settings
         return instance
 
 
-ComponentType = TypeVar('ComponentType', bound='Module')
+ComponentType = TypeVar('ComponentType', bound=Module)
+
 
 def construct_component(cls: Type[ComponentType], main_settings: 'ModuleSettings', *args, **kwargs) -> ComponentType:
     if not getattr(main_settings, "active_modules", None):
@@ -79,7 +80,8 @@ def construct_component(cls: Type[ComponentType], main_settings: 'ModuleSettings
     return cast(ComponentType, main_settings.active_modules[cls])
 
 
-DependencyType = TypeVar('DependencyType', bound='Module')
+DependencyType = TypeVar('DependencyType', bound=Module)
+
 
 class Dependency(Generic[DependencyType]):
     def __init__(self, cls: Type[DependencyType]) -> None:

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -1,3 +1,5 @@
+from typing import cast, Any, Callable, ClassVar, Dict, Generic, List, NoReturn, Optional, Type, TypeVar
+
 __all__ = [
     "Module",
     "Dependency",
@@ -7,28 +9,30 @@ __all__ = [
 
 
 class ModuleSettings:
-    def __init__(self, cls, main_settings):
+    def __init__(self, cls: Type['Module'], main_settings: 'ModuleSettings') -> None:
         object.__setattr__(self, "cls", cls)
         object.__setattr__(self, "main_settings", main_settings)
+        # TODO: can't clarify that active_modules[Type[X]] returns X (https://github.com/python/mypy/issues/4928)
+        self.active_modules: Optional[Dict[Type[Module], Module]] 
 
-    def __getattribute__(self, item):
-        cls = object.__getattribute__(self, "cls")
+    def __getattribute__(self, item: Any) -> Any:  # TODO: narrow down type annotations
+        cls: Type['Module'] = object.__getattribute__(self, "cls")
         main_settings = object.__getattribute__(self, "main_settings")
         for entry in cls.__mro__:
             try:
-                settings = getattr(main_settings, entry.__name__)
+                settings: Any = getattr(main_settings, entry.__name__)  # TODO: narrow down type annotations
                 return getattr(settings, item)
             except AttributeError:
                 continue
 
         raise AttributeError("'" + cls.__name__ + "' object has no setting '" + item + "'")
 
-    def __setattr__(self, key, value):
-        cls = object.__getattribute__(self, "cls")
-        main_settings = object.__getattribute__(self, "main_settings")
+    def __setattr__(self, key: Any, value: Any) -> None:  # TODO: narrow down type annotations
+        cls: Type['Module'] = object.__getattribute__(self, "cls")
+        main_settings: 'ModuleSettings' = object.__getattribute__(self, "main_settings")
         for entry in cls.__mro__:
             try:
-                settings = getattr(main_settings, entry.__name__)
+                settings: Any = getattr(main_settings, entry.__name__)  # TODO: narrow down type annotations
                 getattr(settings, key)
                 setattr(settings, key, value)
                 return
@@ -39,46 +43,58 @@ class ModuleSettings:
 
 
 class Settings:
-    def __init__(self, cls):
-        self.cls = cls
+    def __init__(self, cls: Type['Module']) -> None:
+        self.cls: Type['Module'] = cls
 
-    def __get__(self, obj, objtype=None):
+    def __get__(self, obj: 'Module', objtype: Any = None) -> 'ModuleSettings':
         return ModuleSettings(self.cls, obj.main_settings)
 
-    def __set__(self, obj, settings):
+    def __set__(self, obj: 'Module', settings: 'Settings'):
         setattr(obj.main_settings, self.cls.__name__, settings)
 
 
-class Module:
-    def __new__(cls, main_settings, *args, **kwargs):
-        instance = super(Module, cls).__new__(cls)
+T_Module = TypeVar('T_Module', bound='Module')
+
+class Module(Generic[T_Module]):
+    settings: ClassVar['Settings']
+    main_settings: 'ModuleSettings'
+    def __new__(klass: Type[T_Module], main_settings: 'ModuleSettings', *args, **kwargs) -> T_Module:
+        instance: T_Module = super(Module, klass).__new__(klass)
         instance.main_settings = main_settings
         return instance
 
 
-def construct_component(klass, main_settings, *args, **kwargs):
+T = TypeVar('T', bound='Module')
+
+def construct_component(klass: Type[T], main_settings: 'ModuleSettings', *args, **kwargs) -> T:
     if not getattr(main_settings, "active_modules", None):
         main_settings.active_modules = dict()
 
     if klass not in main_settings.active_modules:
         klass.settings = Settings(klass)
-        instance = klass.__new__(klass, main_settings=main_settings)
-        instance.__init__(*args, **kwargs)
+        instance: T = klass.__new__(klass, main_settings=main_settings)
+        # https://github.com/python/mypy/blob/master/mypy/checkmember.py#180
+        # Accessing __init__ in statically typed code would compromise
+        # type safety unless used via super().
+        instance.__init__(*args, **kwargs)  # type: ignore  
         main_settings.active_modules[klass] = instance
-    return main_settings.active_modules[klass]
+    return cast(T, main_settings.active_modules[klass])
 
 
-class Dependency:
-    def __init__(self, klass):
+T_Dependency = TypeVar('T_Dependency', bound='Module')
+
+class Dependency(Generic[T_Dependency]):
+    def __init__(self, klass: Type[T_Dependency]) -> None:
         self.klass = klass
 
-    def __get__(self, instance, owner):
-        def constructor_function(*args, **kwargs):
+    def __get__(self, instance: T_Dependency, owner: Any) -> Callable[..., T_Dependency]:
+        def constructor_function(*args, **kwargs) -> T_Dependency:
             return construct_component(self.klass, instance.main_settings, *args, **kwargs)
         return constructor_function
 
 
-def get_dependencies(klass, result=None, parent=None):
+def get_dependencies(klass: Type[Module], result: Optional[List[Type[Module]]]=None,
+                     parent: Optional[Dict[Type[Module], Type[Module]]]=None) -> List[Type[Module]]:
     if result is None:
         result = list()
     if parent is None:
@@ -87,6 +103,7 @@ def get_dependencies(klass, result=None, parent=None):
     result.append(klass)
 
     # parent classes
+    all_dependenies: List[Module]
     all_dependencies = [x for x in klass.__mro__ if issubclass(x, Module) and x != Module and x != klass]
     # dependencies
     all_dependencies.extend([x.klass for x in klass.__dict__.values() if isinstance(x, Dependency)])
@@ -100,7 +117,7 @@ def get_dependencies(klass, result=None, parent=None):
     return result
 
 
-def define_arguments_recursive(klass, argument_parser):
+def define_arguments_recursive(klass, argument_parser):  # TODO: return here after ModuleArgumentParser is annotated
     modules = get_dependencies(klass)
 
     for current_module in modules:

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -18,7 +18,7 @@ class ModuleSettings:
         main_settings = object.__getattribute__(self, "main_settings")
         for entry in cls.__mro__:
             try:
-                settings: 'HasModulesMapping' = getattr(main_settings, entry.__name__)
+                settings = getattr(main_settings, entry.__name__)
                 return getattr(settings, item)
             except AttributeError:
                 continue
@@ -30,7 +30,7 @@ class ModuleSettings:
         main_settings: 'HasModulesMapping' = object.__getattribute__(self, "main_settings")
         for entry in cls.__mro__:
             try:
-                settings: 'HasModulesMapping' = getattr(main_settings, entry.__name__)
+                settings = getattr(main_settings, entry.__name__)
                 getattr(settings, key)
                 setattr(settings, key, value)
                 return

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -1,4 +1,4 @@
-from typing import cast, Any, Callable, ClassVar, Dict, Generic, List, NoReturn, Optional, Type, TypeVar
+from typing import cast, Any, Callable, ClassVar, Dict, Generic, List, NoReturn, Optional, Type, TypeVar, Union
 
 __all__ = [
     "Module",
@@ -15,24 +15,24 @@ class ModuleSettings:
         # TODO: can't clarify that active_modules[Type[X]] returns X (https://github.com/python/mypy/issues/4928)
         self.active_modules: Optional[Dict[Type[Module], Module]]
 
-    def __getattribute__(self, item: Any) -> Any:  # TODO: narrow down type annotations
+    def __getattribute__(self, item: str) -> Union[str, List[str]]:
         cls: Type['Module'] = object.__getattribute__(self, "cls")
         main_settings = object.__getattribute__(self, "main_settings")
         for entry in cls.__mro__:
             try:
-                settings: Any = getattr(main_settings, entry.__name__)  # TODO: narrow down type annotations
+                settings: 'Settings' = getattr(main_settings, entry.__name__)
                 return getattr(settings, item)
             except AttributeError:
                 continue
 
         raise AttributeError("'" + cls.__name__ + "' object has no setting '" + item + "'")
 
-    def __setattr__(self, key: Any, value: Any) -> None:  # TODO: narrow down type annotations
+    def __setattr__(self, key: str, value: Union[str, List[str]]) -> None:
         cls: Type['Module'] = object.__getattribute__(self, "cls")
         main_settings: 'ModuleSettings' = object.__getattribute__(self, "main_settings")
         for entry in cls.__mro__:
             try:
-                settings: Any = getattr(main_settings, entry.__name__)  # TODO: narrow down type annotations
+                settings: 'Settings' = getattr(main_settings, entry.__name__)
                 getattr(settings, key)
                 setattr(settings, key, value)
                 return

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -18,7 +18,7 @@ class ModuleSettings:
         main_settings = object.__getattribute__(self, "main_settings")
         for entry in cls.__mro__:
             try:
-                settings: 'Settings' = getattr(main_settings, entry.__name__)
+                settings: 'HasModulesMapping' = getattr(main_settings, entry.__name__)
                 return getattr(settings, item)
             except AttributeError:
                 continue
@@ -30,7 +30,7 @@ class ModuleSettings:
         main_settings: 'HasModulesMapping' = object.__getattribute__(self, "main_settings")
         for entry in cls.__mro__:
             try:
-                settings: 'Settings' = getattr(main_settings, entry.__name__)
+                settings: 'HasModulesMapping' = getattr(main_settings, entry.__name__)
                 getattr(settings, key)
                 setattr(settings, key, value)
                 return

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -80,6 +80,7 @@ def construct_component(cls: Type[ComponentType], main_settings: 'HasModulesMapp
         # https://github.com/python/mypy/blob/master/mypy/checkmember.py#180
         # Accessing __init__ in statically typed code would compromise
         # type safety unless used via super().
+        # noinspection PyArgumentList
         instance.__init__(*args, **kwargs)  # type: ignore
         main_settings.active_modules[cls] = instance
     return cast(ComponentType, main_settings.active_modules[cls])
@@ -123,6 +124,7 @@ def define_arguments_recursive(cls, argument_parser):  # TODO: return here after
     for current_module in modules:
         if "define_arguments" in current_module.__dict__:
             argument_parser.dest_prefix = current_module.__name__ + '.'
+            # noinspection PyUnresolvedReferences
             current_module.define_arguments(argument_parser)
 
     argument_parser.dest_prefix = ''

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -1,5 +1,7 @@
-from typing import cast, Any, Callable, ClassVar, Dict, Generic, List, Optional, Type, TypeVar, TYPE_CHECKING, Union
+from typing import cast, Any, Callable, ClassVar, Dict, Generic, List, Optional, Type, TypeVar, Union
+
 from typing_extensions import Protocol
+
 __all__ = [
     "Module",
     "Dependency",

--- a/universum/lib/module_arguments.py
+++ b/universum/lib/module_arguments.py
@@ -1,19 +1,13 @@
 # pylint: disable = protected-access
 
-from typing import Dict, Type, TYPE_CHECKING
-
 import argparse
 import os
 import sys
 
-if TYPE_CHECKING:
-    from .gravity import Module  # for static type check
+from .gravity import HasModulesMapping
 
 
-class ModuleNamespace(argparse.Namespace):
-
-    if TYPE_CHECKING:
-        active_modules: Dict[Type['Module'], 'Module']
+class ModuleNamespace(argparse.Namespace, HasModulesMapping):
 
     def __setattr__(self, name, value):
         if '.' in name:

--- a/universum/lib/module_arguments.py
+++ b/universum/lib/module_arguments.py
@@ -4,10 +4,8 @@ import argparse
 import os
 import sys
 
-from .gravity import HasModulesMapping
 
-
-class ModuleNamespace(argparse.Namespace, HasModulesMapping):
+class ModuleNamespace(argparse.Namespace):
 
     def __setattr__(self, name, value):
         if '.' in name:

--- a/universum/lib/module_arguments.py
+++ b/universum/lib/module_arguments.py
@@ -1,11 +1,19 @@
 # pylint: disable = protected-access
 
+from typing import Dict, Type, TYPE_CHECKING
+
 import argparse
 import os
 import sys
 
+if TYPE_CHECKING:
+    from .gravity import Module  # for static type check
+
 
 class ModuleNamespace(argparse.Namespace):
+
+    if TYPE_CHECKING:
+        active_modules: Dict[Type[Module], Module]
 
     def __setattr__(self, name, value):
         if '.' in name:

--- a/universum/lib/module_arguments.py
+++ b/universum/lib/module_arguments.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 class ModuleNamespace(argparse.Namespace):
 
     if TYPE_CHECKING:
-        active_modules: Dict[Type[Module], Module]
+        active_modules: Dict[Type['Module'], 'Module']
 
     def __setattr__(self, name, value):
         if '.' in name:

--- a/universum/lib/module_arguments.py
+++ b/universum/lib/module_arguments.py
@@ -6,6 +6,7 @@ import sys
 
 
 class ModuleNamespace(argparse.Namespace):
+
     def __setattr__(self, name, value):
         if '.' in name:
             group, name = name.split('.', 1)

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -81,7 +81,7 @@ class Block:
 class StructureHandler(Module):
     def __init__(self, *args, **kwargs):
         super(StructureHandler, self).__init__(*args, **kwargs)
-        self.current_block: Block = Block("Universum")
+        self.current_block: Optional[Block] = Block("Universum")
         self.configs_current_number: int = 0
         self.configs_total_count: int = 0
         self.active_background_steps = []
@@ -94,9 +94,10 @@ class StructureHandler(Module):
         self.out.open_block(new_block.number, name)
 
     def close_block(self) -> None:
-        block = self.current_block
-        self.current_block = self.current_block.parent
-        self.out.close_block(block.number, block.name, block.status)
+        if self.current_block is not None:
+            block: Block = self.current_block
+            self.current_block = self.current_block.parent
+            self.out.close_block(block.number, block.name, block.status)
 
     def report_critical_block_failure(self) -> None:
         self.out.report_skipped("Critical step failed. All further configurations will be skipped")

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -19,8 +19,8 @@ class HasStructure():
 
 def needs_structure(cls: Type) -> Type['HasStructure']:
     cast(Type['HasStructure'], cls)
-    klass.structure_factory = Dependency(StructureHandler)
-    original_init = klass.__init__
+    cls.structure_factory = Dependency(StructureHandler)
+    original_init = cls.__init__
 
     def new_init(self, *args, **kwargs):
         self.structure = self.structure_factory()

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -1,10 +1,11 @@
 import copy
 
+from typing import Any, Callable, List, Optional
 from .. import configuration_support
 from ..lib.ci_exception import SilentAbortException, StepException, CriticalCiException
 from ..lib.gravity import Module, Dependency
 from .output import needs_output
-from typing import Any, Callable, List, Optional
+
 __all__ = [
     "needs_structure"
 ]

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -1,6 +1,6 @@
 import copy
 
-from typing import cast, Any, Callable, ClassVar, List, NewType, Optional, Type, TypeVar
+from typing import cast, Callable, ClassVar, List, Optional, Type
 from .. import configuration_support
 from ..lib.ci_exception import SilentAbortException, StepException, CriticalCiException
 from ..lib.gravity import Module, Dependency
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 
-class HasStructure():
+class HasStructure:
     structure_factory: ClassVar[Dependency['StructureHandler']]
     structure: 'StructureHandler'
 

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -17,6 +17,7 @@ class HasStructure:
 
 
 def needs_structure(cls: Type) -> Type['HasStructure']:
+    # noinspection PyTypeChecker
     cast(Type['HasStructure'], cls)
     cls.structure_factory = Dependency(StructureHandler)
     original_init = cls.__init__
@@ -26,6 +27,7 @@ def needs_structure(cls: Type) -> Type['HasStructure']:
         original_init(self, *args, **kwargs)
 
     cls.__init__ = new_init
+    # noinspection PyTypeChecker
     return cls
 
 
@@ -85,6 +87,7 @@ class StructureHandler(Module):
         self.configs_current_number: int = 0
         self.configs_total_count: int = 0
         self.active_background_steps = []
+        # noinspection PyUnresolvedReferences
         self.out: 'Output'  # TODO: add annotations in ./universum/module/output/output.py for @needs_output
 
     def open_block(self, name: str) -> None:

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -1,6 +1,6 @@
 import copy
 
-from typing import cast, Any, Callable, List, NewType, Optional, Type, TypeVar
+from typing import cast, Any, Callable, ClassVar, List, NewType, Optional, Type, TypeVar
 from .. import configuration_support
 from ..lib.ci_exception import SilentAbortException, StepException, CriticalCiException
 from ..lib.gravity import Module, Dependency
@@ -12,9 +12,8 @@ __all__ = [
 
 
 class HasStructure():
-    structure_factory: Dependency['StructureHandler']
-    def __init__(self):
-        structure: 'StructureHandler'
+    structure_factory: ClassVar[Dependency['StructureHandler']]
+    structure: 'StructureHandler'
 
 
 def needs_structure(cls: Type) -> Type['HasStructure']:

--- a/universum/modules/vcs/git_vcs.py
+++ b/universum/modules/vcs/git_vcs.py
@@ -2,7 +2,7 @@ import glob
 import importlib
 import os
 
-from .base_vcs import BaseVcs, BaseDownloadVcs
+from .base_vcs import BaseVcs, BaseDownloadVcs, BasePollVcs, BaseSubmitVcs
 from ..output import needs_output
 from ..structure_handler import needs_structure
 from ...lib import utils
@@ -196,7 +196,7 @@ class GitMainVcs(GitVcs, BaseDownloadVcs):
 
 
 @needs_output
-class GitSubmitVcs(GitVcs):
+class GitSubmitVcs(GitVcs, BaseSubmitVcs):
     @staticmethod
     def define_arguments(argument_parser):
         parser = argument_parser.get_or_create_group("Git")
@@ -304,7 +304,7 @@ class GitSubmitVcs(GitVcs):
         return change
 
 
-class GitPollVcs(GitVcs):
+class GitPollVcs(GitVcs, BasePollVcs):
     def get_changes(self, changes_reference=None, max_number='1'):
         self.clone_and_fetch()
         if not changes_reference:

--- a/universum/modules/vcs/vcs.py
+++ b/universum/modules/vcs/vcs.py
@@ -1,9 +1,8 @@
+from typing import Dict, List, Type, Union
 import inspect
 import json
 import shutil
 import sh
-
-from typing import cast, Dict, List, Type, Union
 
 from . import git_vcs, github_vcs, gerrit_vcs, perforce_vcs, local_vcs, base_vcs
 from .. import artifact_collector
@@ -58,7 +57,7 @@ def create_vcs(class_type: str = None) -> Type[ProjectDirectory]:
     @needs_structure
     class Vcs(ProjectDirectory):
         driver_factory: Dict[str, Dependency] = {vcs_type: Dependency(cls)
-                                                       for vcs_type, cls in driver_factory_class.items()}
+                                                 for vcs_type, cls in driver_factory_class.items()}
 
         @staticmethod
         def define_arguments(argument_parser):

--- a/universum/modules/vcs/vcs.py
+++ b/universum/modules/vcs/vcs.py
@@ -127,6 +127,7 @@ SubmitVcs: Type[ProjectDirectory] = create_vcs("submit")
 class MainVcs(create_vcs()):  # type: ignore  # https://github.com/python/mypy/issues/2477
     artifacts_factory = Dependency(artifact_collector.ArtifactCollector)
     api_support_factory = Dependency(ApiSupport)
+    driver: Union[base_vcs.BasePollVcs, base_vcs.BaseSubmitVcs, base_vcs.BaseDownloadVcs]
 
     @staticmethod
     def define_arguments(argument_parser):

--- a/universum/modules/vcs/vcs.py
+++ b/universum/modules/vcs/vcs.py
@@ -111,7 +111,6 @@ def create_vcs(class_type: str = None) -> Type[ProjectDirectory]:
                     driver_factory = self.perforce_driver_factory
             except AttributeError:
                 raise NotImplementedError()
-            dir(driver_factory)
             self.driver = driver_factory()
 
         @make_block("Finalizing")


### PR DESCRIPTION
# Description

Without the fix, checking 'main' using mypy generates some errors. With the fix the only remaining errors are due to lack of static type annotations in the dependencies (third-party libraries).
To make static analysis of 'vcs' module meaningful, some minor refactoring was needed.
Also, added static type annotations highlighted some missing dependencies in 'git_vcs'.

!!! Please note that no tests have been run yet - this is preliminary pull request for some early feedback.

# Checklist:

- [x] My code follows the [PEP 8](https://www.python.org/dev/peps/pep-0008/)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
