### PR TITLE
fix(gravity): incorrect type in Dependency

### DIFF
--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -96,7 +96,7 @@ class Dependency(Generic[DependencyType]):
     # The source and the target of the dependency are different modules,
     # so we need to use different type variables to annotate them.
     # instance parameter of the __get__ method is source module.
-    def __get__(self, instance: ComponentType, owner: Any) -> Callable[..., DependencyType]:
+    def __get__(self, instance: Module, owner: Any) -> Callable[..., DependencyType]:
         def constructor_function(*args, **kwargs) -> DependencyType:
             return construct_component(self.cls, instance.main_settings, *args, **kwargs)
         return constructor_function

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -93,7 +93,10 @@ class Dependency(Generic[DependencyType]):
     def __init__(self, cls: Type[DependencyType]) -> None:
         self.cls = cls
 
-    def __get__(self, instance: DependencyType, owner: Any) -> Callable[..., DependencyType]:
+    # the source and the target of the dependency are different modules,
+    # so wee need to use different type variables to annotate them
+    # instance parameter of the __get__ method is source module
+    def __get__(self, instance: ComponentType, owner: Any) -> Callable[..., DependencyType]:
         def constructor_function(*args, **kwargs) -> DependencyType:
             return construct_component(self.cls, instance.main_settings, *args, **kwargs)
         return constructor_function

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -93,9 +93,9 @@ class Dependency(Generic[DependencyType]):
     def __init__(self, cls: Type[DependencyType]) -> None:
         self.cls = cls
 
-    # the source and the target of the dependency are different modules,
-    # so wee need to use different type variables to annotate them
-    # instance parameter of the __get__ method is source module
+    # The source and the target of the dependency are different modules,
+    # so we need to use different type variables to annotate them.
+    # instance parameter of the __get__ method is source module.
     def __get__(self, instance: ComponentType, owner: Any) -> Callable[..., DependencyType]:
         def constructor_function(*args, **kwargs) -> DependencyType:
             return construct_component(self.cls, instance.main_settings, *args, **kwargs)

--- a/universum/submit.py
+++ b/universum/submit.py
@@ -30,8 +30,8 @@ class Submit(Module):
                             help="List of vcs or directories to be reconciled for commit. "
                                  "Relative paths starting at client root are supported")
 
-    def __init__(self, *args, **kwargs):
-        super(Submit, self).__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore
         if not getattr(self.settings, "commit_message", None):
             raise IncorrectParameterError("commit message is not specified.\n\n"
                                           "Please use '--commit-message' option or COMMIT_MESSAGE\n"


### PR DESCRIPTION
The Dependency class was annotated as using the same type for both
source and and target module of the dependency. Because of this
incorrect annotation, mypy produces the error at the place in the code,
where the source module calls the factory to construct the target
module.

Fixed by using two distinct type variables: one for source and one for
target.

Also, added type annotation in one method in submitter to properly
demonstrate the issue.
