### PR TITLE
refactor: needs_output -> HasOutput

### DIFF
--- a/universum/github_handler.py
+++ b/universum/github_handler.py
@@ -2,7 +2,7 @@ import json
 import urllib.parse
 
 from .modules.vcs.github_vcs import GithubToken
-from .modules.output import needs_output
+from .modules.output import HasOutput
 from .modules.structure_handler import needs_structure
 from .lib.ci_exception import CriticalCiException
 from .lib.utils import make_block
@@ -10,8 +10,7 @@ from .lib import utils
 
 
 @needs_structure
-@needs_output
-class GithubHandler(GithubToken):
+class GithubHandler(HasOutput, GithubToken):
 
     @staticmethod
     def define_arguments(argument_parser):

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -93,7 +93,7 @@ class Dependency(Generic[DependencyType]):
     def __init__(self, cls: Type[DependencyType]) -> None:
         self.cls = cls
 
-    def __get__(self, instance: DependencyType, owner: Any) -> Callable[..., DependencyType]:
+    def __get__(self, instance: Module, owner: Any) -> Callable[..., DependencyType]:
         def constructor_function(*args, **kwargs) -> DependencyType:
             return construct_component(self.cls, instance.main_settings, *args, **kwargs)
         return constructor_function

--- a/universum/main.py
+++ b/universum/main.py
@@ -2,13 +2,12 @@ from . import __title__
 from .lib.ci_exception import SilentAbortException
 from .lib.gravity import Module, Dependency
 from .modules import vcs, artifact_collector, reporter, launcher, code_report_collector
-from .modules.output import needs_output
+from .modules.output import HasOutput
 
 __all__ = ["Main"]
 
 
-@needs_output
-class Main(Module):
+class Main(HasOutput, Module):
     description = __title__
     vcs_factory = Dependency(vcs.MainVcs)
     launcher_factory = Dependency(launcher.Launcher)

--- a/universum/modules/artifact_collector.py
+++ b/universum/modules/artifact_collector.py
@@ -13,7 +13,7 @@ from ..lib.gravity import Dependency
 from ..lib.utils import make_block
 from ..lib import utils
 from .automation_server import AutomationServerForHostingBuild
-from .output import needs_output
+from .output import HasOutput
 from .project_directory import ProjectDirectory
 from .reporter import Reporter
 from .structure_handler import needs_structure
@@ -56,9 +56,8 @@ def make_big_archive(target, source):
     return filename
 
 
-@needs_output
 @needs_structure
-class ArtifactCollector(ProjectDirectory):
+class ArtifactCollector(HasOutput, ProjectDirectory):
     reporter_factory = Dependency(Reporter)
     automation_server_factory = Dependency(AutomationServerForHostingBuild)
 

--- a/universum/modules/automation_server/jenkins_server.py
+++ b/universum/modules/automation_server/jenkins_server.py
@@ -2,7 +2,7 @@ import os
 
 from ...lib.module_arguments import IncorrectParameterError
 from ...lib import utils
-from ..output import needs_output
+from ..output import HasOutput
 from .base_server import BaseServerForHostingBuild, BaseServerForTrigger
 
 __all__ = [
@@ -11,8 +11,7 @@ __all__ = [
 ]
 
 
-@needs_output
-class JenkinsServerForTrigger(BaseServerForTrigger):
+class JenkinsServerForTrigger(HasOutput, BaseServerForTrigger):
 
     @staticmethod
     def define_arguments(argument_parser):

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -4,7 +4,7 @@ import json
 import os
 
 from universum.configuration_support import Variations
-from .output import needs_output
+from .output import HasOutput
 from .project_directory import ProjectDirectory
 from . import artifact_collector, reporter
 from ..lib import utils
@@ -13,9 +13,8 @@ from ..lib.utils import make_block
 from .structure_handler import needs_structure
 
 
-@needs_output
 @needs_structure
-class CodeReportCollector(ProjectDirectory):
+class CodeReportCollector(HasOutput, ProjectDirectory):
     reporter_factory = Dependency(reporter.Reporter)
     artifacts_factory = Dependency(artifact_collector.ArtifactCollector)
 

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -12,7 +12,7 @@ from ..lib.gravity import Dependency
 from ..lib.module_arguments import IncorrectParameterError
 from ..lib.utils import make_block
 from . import automation_server, api_support, artifact_collector, reporter, code_report_collector
-from .output import needs_output
+from .output import HasOutput
 from .project_directory import ProjectDirectory
 from .structure_handler import needs_structure
 
@@ -287,9 +287,8 @@ class Step:
         self._postponed_out = []
 
 
-@needs_output
 @needs_structure
-class Launcher(ProjectDirectory):
+class Launcher(HasOutput, ProjectDirectory):
     artifacts_factory = Dependency(artifact_collector.ArtifactCollector)
     api_support_factory = Dependency(api_support.ApiSupport)
     reporter_factory = Dependency(reporter.Reporter)

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -4,21 +4,8 @@ from .terminal_based_output import TerminalBasedOutput
 from .teamcity_output import TeamcityOutput
 
 __all__ = [
-    "needs_output"
+    "HasOutput"
 ]
-
-
-def needs_output(klass):
-    klass.out_factory = Dependency(Output)
-    original_init = klass.__init__
-
-    def new_init(self, *args, **kwargs):
-        self.out = self.out_factory()
-        original_init(self, *args, **kwargs)
-
-    klass.__init__ = new_init
-
-    return klass
 
 
 class Output(Module):
@@ -72,3 +59,11 @@ class Output(Module):
 
     def log_shell_output(self, line):
         self.driver.log_shell_output(line)
+
+
+class HasOutput(Module):
+    out_factory = Dependency(Output)
+
+    def __init__(self, *args, **kwargs):
+        super(HasOutput, self).__init__(*args, **kwargs)
+        self.out = self.out_factory()

--- a/universum/modules/reporter.py
+++ b/universum/modules/reporter.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from ..lib.gravity import Module, Dependency
 from ..lib.utils import make_block
 from . import automation_server
-from .output import needs_output
+from .output import HasOutput
 from .structure_handler import needs_structure
 
 __all__ = [
@@ -30,9 +30,8 @@ class ReportObserver:
         raise NotImplementedError
 
 
-@needs_output
 @needs_structure
-class Reporter(Module):
+class Reporter(HasOutput, Module):
     automation_server_factory = Dependency(automation_server.AutomationServerForHostingBuild)
 
     @staticmethod

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -4,7 +4,7 @@ from typing import cast, Callable, ClassVar, List, Optional, Type
 from .. import configuration_support
 from ..lib.ci_exception import SilentAbortException, StepException, CriticalCiException
 from ..lib.gravity import Module, Dependency
-from .output import needs_output
+from .output import HasOutput
 
 __all__ = [
     "needs_structure"
@@ -79,8 +79,7 @@ class Block:
         return self.status == "Success"
 
 
-@needs_output
-class StructureHandler(Module):
+class StructureHandler(HasOutput, Module):
     def __init__(self, *args, **kwargs):
         super(StructureHandler, self).__init__(*args, **kwargs)
         self.current_block: Optional[Block] = Block("Universum")

--- a/universum/modules/vcs/git_vcs.py
+++ b/universum/modules/vcs/git_vcs.py
@@ -3,7 +3,7 @@ import importlib
 import os
 
 from .base_vcs import BaseVcs, BaseDownloadVcs, BasePollVcs, BaseSubmitVcs
-from ..output import needs_output
+from ..output import HasOutput
 from ..structure_handler import needs_structure
 from ...lib import utils
 from ...lib.ci_exception import CriticalCiException
@@ -23,9 +23,8 @@ def catch_git_exception(ignore_if=None):
     return utils.catch_exception("GitCommandError", ignore_if)
 
 
-@needs_output
 @needs_structure
-class GitVcs(BaseVcs):
+class GitVcs(HasOutput, BaseVcs):
     """
     This class contains CI functions for interaction with Git
     """
@@ -103,9 +102,8 @@ class GitVcs(BaseVcs):
             self.repo = git.Repo.clone_from(clone_url, destination_directory, progress=self.logger)
 
 
-@needs_output
 @needs_structure
-class GitMainVcs(GitVcs, BaseDownloadVcs):
+class GitMainVcs(GitVcs, HasOutput, BaseDownloadVcs):
     @staticmethod
     def define_arguments(argument_parser):
         parser = argument_parser.get_or_create_group("Git")
@@ -195,8 +193,7 @@ class GitMainVcs(GitVcs, BaseDownloadVcs):
         raise NotImplementedError
 
 
-@needs_output
-class GitSubmitVcs(GitVcs, BaseSubmitVcs):
+class GitSubmitVcs(GitVcs, HasOutput, BaseSubmitVcs):
     @staticmethod
     def define_arguments(argument_parser):
         parser = argument_parser.get_or_create_group("Git")

--- a/universum/modules/vcs/local_vcs.py
+++ b/universum/modules/vcs/local_vcs.py
@@ -5,7 +5,7 @@ from ...lib.ci_exception import CriticalCiException
 from ...lib.module_arguments import IncorrectParameterError
 from ...lib.utils import make_block
 from ...lib import utils
-from ..output import needs_output
+from ..output import HasOutput
 from ..structure_handler import needs_structure
 from . import base_vcs
 
@@ -14,9 +14,8 @@ __all__ = [
 ]
 
 
-@needs_output
 @needs_structure
-class LocalMainVcs(base_vcs.BaseDownloadVcs):
+class LocalMainVcs(HasOutput, base_vcs.BaseDownloadVcs):
     @staticmethod
     def define_arguments(argument_parser):
         parser = argument_parser.get_or_create_group("Local files",

--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -12,7 +12,7 @@ from ...lib.gravity import Dependency
 from ...lib.module_arguments import IncorrectParameterError
 from ...lib.utils import make_block, Uninterruptible, convert_to_str
 from ...lib import utils
-from ..output import needs_output
+from ..output import HasOutput
 from ..structure_handler import needs_structure
 from . import base_vcs
 from .swarm import Swarm
@@ -31,9 +31,8 @@ def catch_p4exception(ignore_if=None):
     return utils.catch_exception("P4Exception", ignore_if)
 
 
-@needs_output
 @needs_structure
-class PerforceVcs(base_vcs.BaseVcs):
+class PerforceVcs(HasOutput, base_vcs.BaseVcs):
     """
     This class contains global functions for interaction with Perforce
     """

--- a/universum/modules/vcs/swarm.py
+++ b/universum/modules/vcs/swarm.py
@@ -6,7 +6,7 @@ from ...lib.gravity import Module, Dependency
 from ...lib.module_arguments import IncorrectParameterError
 from ...lib import utils
 from ..reporter import ReportObserver, Reporter
-from ..output import needs_output
+from ..output import HasOutput
 
 urllib3.disable_warnings((urllib3.exceptions.InsecurePlatformWarning, urllib3.exceptions.SNIMissingWarning))
 
@@ -16,8 +16,7 @@ __all__ = [
 ]
 
 
-@needs_output
-class Swarm(ReportObserver, Module):
+class Swarm(HasOutput, ReportObserver, Module):
     """
     This class contains CI functions for interaction with Swarm via 'swarm_cli.py'
     """

--- a/universum/poll.py
+++ b/universum/poll.py
@@ -3,15 +3,14 @@ import json
 from .lib.gravity import Module, Dependency
 from .lib.utils import make_block
 from .modules import automation_server, vcs
-from .modules.output import needs_output
+from .modules.output import HasOutput
 from .modules.structure_handler import needs_structure
 
 __all__ = ["Poll"]
 
 
-@needs_output
 @needs_structure
-class Poll(Module):
+class Poll(HasOutput, Module):
     description = "Polling module of Universum"
     vcs_factory = Dependency(vcs.PollVcs)
     server_factory = Dependency(automation_server.AutomationServerForTrigger)

--- a/universum/submit.py
+++ b/universum/submit.py
@@ -3,15 +3,14 @@ from .lib.gravity import Module, Dependency
 from .lib.module_arguments import IncorrectParameterError
 from .lib.utils import make_block
 from .modules import vcs
-from .modules.output import needs_output
+from .modules.output import HasOutput
 from .modules.structure_handler import needs_structure
 
 __all__ = ["Submit"]
 
 
-@needs_output
 @needs_structure
-class Submit(Module):
+class Submit(HasOutput, Module):
     description = "Submitting module of Universum"
     vcs_factory = Dependency(vcs.SubmitVcs)
 


### PR DESCRIPTION
# Description

Using needs_output to add .out attribute was a bit confusing,
and especially hard to align with static typing
Inheritance-based approach seems more natural (interface-like)
and should be more compatible with type annotations

# How Has This Been Tested?

Existing tests fully cover the change

# Checklist:

- [ ] My code follows the [PEP 8](https://www.python.org/dev/peps/pep-0008/)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
