### PR TITLE
feat(args): printing multiple errors in p4, submit

### DIFF
--- a/universum/modules/error_state.py
+++ b/universum/modules/error_state.py
@@ -23,7 +23,7 @@ class HasErrorState(Module):
         super().__init__(*args, **kwargs)  # type: ignore
         self.global_error_state: GlobalErrorState = self.global_error_state_factory()
 
-    def error(self, message: str):
+    def error(self, message: str) -> None:
         self.global_error_state.errors.append(inspect.cleandoc(message))
 
     def is_in_error_state(self) -> bool:

--- a/universum/modules/error_state.py
+++ b/universum/modules/error_state.py
@@ -29,6 +29,6 @@ class HasErrorState(Module):
     def is_in_error_state(self) -> bool:
         return self.global_error_state.is_in_error_state()
 
-    def check_required_option(self, setting_name, message) -> None:
+    def check_required_option(self, setting_name: str, message: str) -> None:
         if not getattr(self.settings, setting_name, None):
             self.error(message)

--- a/universum/modules/error_state.py
+++ b/universum/modules/error_state.py
@@ -9,10 +9,10 @@ class GlobalErrorState(Module):
         super().__init__(*args, **kwargs)  # type: ignore
         self.errors: List[str] = []
 
-    def get_errors(self):
+    def get_errors(self) -> List[str]:
         return self.errors
 
-    def is_in_error_state(self):
+    def is_in_error_state(self) -> bool:
         return len(self.errors) > 0
 
 
@@ -21,10 +21,14 @@ class HasErrorState(Module):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)  # type: ignore
-        self.global_error_state = self.global_error_state_factory()
+        self.global_error_state: GlobalErrorState = self.global_error_state_factory()
 
     def error(self, message: str):
         self.global_error_state.errors.append(inspect.cleandoc(message))
 
-    def is_in_error_state(self):
+    def is_in_error_state(self) -> bool:
         return self.global_error_state.is_in_error_state()
+
+    def check_required_option(self, setting_name, message) -> None:
+        if not getattr(self.settings, setting_name, None):
+            self.error(message)

--- a/universum/submit.py
+++ b/universum/submit.py
@@ -1,15 +1,15 @@
 from .lib import utils
-from .lib.gravity import Module, Dependency
-from .lib.module_arguments import IncorrectParameterError
+from .lib.gravity import Dependency
 from .lib.utils import make_block
 from .modules import vcs
+from .modules.error_state import HasErrorState
 from .modules.output import HasOutput
 from .modules.structure_handler import HasStructure
 
 __all__ = ["Submit"]
 
 
-class Submit(HasOutput, HasStructure):
+class Submit(HasOutput, HasStructure, HasErrorState):
     description = "Submitting module of Universum"
     vcs_factory = Dependency(vcs.SubmitVcs)
 
@@ -30,10 +30,12 @@ class Submit(HasOutput, HasStructure):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        if not getattr(self.settings, "commit_message", None):
-            raise IncorrectParameterError("commit message is not specified.\n\n"
-                                          "Please use '--commit-message' option or COMMIT_MESSAGE\n"
-                                          "environment variable")
+
+        self.check_required_option("commit_message", """
+            Commit message is not specified.
+            
+            Please use '--commit-message' option or COMMIT_MESSAGE environment variable.
+            """)
 
         self.vcs = self.vcs_factory()
         self.client = None


### PR DESCRIPTION
Also removed tests with deleting fields from settings objects. If the
fields is absent, the error state mechanism is able to detect it and
remember the error. However, the code in the module still can access the
field. Such accesses result in exceptions raised from gravity.

This is not an issue for normal operation, because when user launches
the script, all settings fields are present.