### PR TITLE
fix(test): set artifacts dir for nonci tests

### DIFF
--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -191,11 +191,8 @@ class UniversumRunner:
             self.environment.install_python_module(self.working_dir)
             self.environment.install_python_module("coverage")
 
-    def _basic_args(self):
-        return " -lo console -ad '{}'".format(self.artifact_dir)
-
     def _mandatory_args(self, config_file):
-        result = f" -lcp '{config_file}'"
+        result = f" -lcp '{config_file}' -ad '{self.artifact_dir}'"
         if self.project_root:
             result += f" -pr '{self.project_root}'"
         return result
@@ -240,7 +237,7 @@ class UniversumRunner:
         if self.nonci:
             cmd += ' nonci'
         else:
-            cmd += self._basic_args() + self._vcs_args(vcs_type)
+            cmd += " -lo console" + self._vcs_args(vcs_type)
 
         config_file = self._create_temp_config(config)
         cmd += self._mandatory_args(config_file) + ' ' + additional_parameters

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -79,13 +79,10 @@ configs = Variations([dict(name="Bad step", command=["ls", "not_a_file"]),
                       background=True, artifacts="file")])
 """)
     assert "All ongoing background steps completed" in log
-    artifacts_must_collect = not docker_main_and_nonci.nonci
-    assert artifacts_must_collect == os.path.exists(
-        os.path.join(docker_main_and_nonci.artifact_dir, "file"))
+    assert os.path.exists(os.path.join(docker_main_and_nonci.artifact_dir, "file"))
 
     # Test TC step failing
-    if artifacts_must_collect:
-        docker_main_and_nonci.clean_artifacts()
+    docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
 from universum.configuration_support import Variations
 
@@ -94,8 +91,7 @@ configs = Variations([dict(name="Bad bg step", command=["ls", "not_a_file"], bac
     assert "##teamcity[buildProblem description" in log
 
     # Test multiple failing background steps
-    if artifacts_must_collect:
-        docker_main_and_nonci.clean_artifacts()
+    docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
 from universum.configuration_support import Variations
 

--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -27,7 +27,7 @@ def test_launcher_output(docker_nonci):
     pwd_string_in_logs = f"pwd:[{cwd}]"
 
     docker_nonci.environment.assert_successful_execution(
-        f"bash -c 'mkdir {artifacts}; echo \"Old artifact\" > {artifacts}/test_nonci.txt'")
+        f"bash -c 'mkdir \"{artifacts}\"; echo \"Old artifact\" > \"{artifacts}/test_nonci.txt\"'")
 
     docker_nonci.project_root = None
     console_out_log = docker_nonci.run(config.format(artifacts), workdir=cwd)
@@ -49,7 +49,7 @@ def test_launcher_output(docker_nonci):
 
     assert console_out_log != log
     step_log = docker_nonci.environment.assert_successful_execution(
-        f"cat {artifacts}/test_step_log.txt")
+        f"cat '{artifacts}/test_step_log.txt'")
     assert pwd_string_in_logs in step_log
 
     # second call of universum must not contain previous step log
@@ -61,7 +61,7 @@ configs = Variations([dict(name="test_step",
 """, additional_parameters='-lo file', workdir=cwd)
 
     second_run_step_log = docker_nonci.environment.assert_successful_execution(
-        f"cat {artifacts}/test_step_log.txt")
+        f"cat '{artifacts}/test_step_log.txt'")
     assert pwd_string_in_logs not in second_run_step_log
     assert "Separate run" in second_run_step_log
 


### PR DESCRIPTION
Before this fix the artifacts directory was not specified for nonci
tests running in docker. This resulted in universum automatically
calculating it as ‘artifacts’ subdirectory of the current directory,
which is root (“/”). This is confusing and also results in artifacts
missing in a proper place.

Fixed by always specifying artifacts directory for running universum in
docker by using ‘-ad’ command-line parameter. Also fixed artifact checks
in tests accordingly.
