### PR TITLE
fix(test): warning produced during pytest run

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/tests/test_argument_check.py
+++ b/tests/test_argument_check.py
@@ -173,7 +173,7 @@ def test_missing_params(unset, test_type, module, field, vcs_type, error_match):
     settings = create_settings(test_type, vcs_type)
     unset(settings, module, field)
 
-    assert_incorrect_parameter(settings, "(?i)" + error_match)
+    assert_incorrect_parameter(settings, error_match)
 
 
 @pytest.mark.parametrize("test_type, module, field, vcs_type, error_match", missing_params)


### PR DESCRIPTION
During tests execution, the pytest produces the warning regarding future
change of the default format of the junit report. The solution is to
explicitly set the format. Fixed by setting the format to the new
version.

Also fixed the warning caused by the regular expressions.