### PR TITLE
feat(args): printing multiple errors in swarm, vcs

### DIFF
--- a/tests/test_argument_check.py
+++ b/tests/test_argument_check.py
@@ -308,7 +308,7 @@ def test_swarm_changelist_incorrect_format():
     assert_incorrect_parameter(settings, "changelist for unshelving is incorrect")
 
 
-def test_vcs_type_and_config_path():
+def test_multiple_errors_main_vcs_type_and_config_path():
     settings = create_settings("main", "p4")
     settings.Launcher.config_path = None
     settings.Vcs.type = None
@@ -316,24 +316,47 @@ def test_vcs_type_and_config_path():
     assert_incorrect_parameter(settings, "CONFIG_PATH", "repository type")
 
 
-def test_source_dir_and_config_path():
+def test_multiple_errors_main_none_source_dir_and_config_path():
     settings = create_settings("main", "none")
     settings.Launcher.config_path = None
     settings.LocalMainVcs.source_dir = None
+    settings.MainVcs.report_to_review = True
 
-    assert_incorrect_parameter(settings, "CONFIG_PATH", "SOURCE_DIR")
+    assert_incorrect_parameter(settings, "CONFIG_PATH", "SOURCE_DIR", "no code review system")
 
 
 def test_multiple_errors_main_p4_params_and_config_path():
     settings = create_settings("main", "p4")
+
     settings.Launcher.config_path = None
     settings.PerforceVcs.port = None
     settings.PerforceVcs.user = None
     settings.PerforceVcs.password = None
     settings.PerforceMainVcs.client = None
     settings.PerforceWithMappings.project_depot_path = None
+    settings.Swarm.review_id = None
+    settings.Swarm.change = None
+    settings.Swarm.server_url = None
 
-    assert_incorrect_parameter(settings, "CONFIG_PATH", "port", "user name", "password", "mappings", "workspace")
+    assert_incorrect_parameter(settings, "CONFIG_PATH", "port", "user name", "password", "mappings", "workspace",
+                               "URL of the Swarm", "Swarm review number",
+                               "Swarm changelist for unshelving is not specified")
+
+    settings = create_settings("main", "p4")
+
+    settings.Launcher.config_path = None
+    settings.PerforceVcs.port = None
+    settings.PerforceVcs.user = None
+    settings.PerforceVcs.password = None
+    settings.PerforceMainVcs.client = None
+    settings.PerforceWithMappings.project_depot_path = None
+    settings.Swarm.review_id = None
+    settings.Swarm.change = "123,456"
+    settings.Swarm.server_url = None
+
+    assert_incorrect_parameter(settings, "CONFIG_PATH", "port", "user name", "password", "mappings", "workspace",
+                               "URL of the Swarm", "Swarm review number",
+                               "Swarm changelist for unshelving is incorrect")
 
 
 def test_multiple_errors_submit_p4_params_and_commit_message():
@@ -351,8 +374,9 @@ def test_multiple_errors_main_git_params_and_config_path():
     settings = create_settings("main", "git")
     settings.Launcher.config_path = None
     settings.GitVcs.repo = None
+    settings.MainVcs.report_to_review = True
 
-    assert_incorrect_parameter(settings, "CONFIG_PATH", "repo")
+    assert_incorrect_parameter(settings, "CONFIG_PATH", "repo", "no code review system")
 
 
 def test_multiple_errors_submit_git_params_commit_message():

--- a/universum/modules/vcs/base_vcs.py
+++ b/universum/modules/vcs/base_vcs.py
@@ -1,5 +1,6 @@
 import shutil
 
+from ..error_state import HasErrorState
 from ...lib.ci_exception import CiException
 from ...lib.module_arguments import IncorrectParameterError
 from ...lib.utils import make_block
@@ -45,13 +46,13 @@ class BaseVcs(ProjectDirectory):
             self.clean_sources()
 
 
-class BaseDownloadVcs(BaseVcs):
+class BaseDownloadVcs(BaseVcs, HasErrorState):
     """
     Base class for default CI build VCS drivers
     """
 
-    def code_review(self):  # pylint: disable=no-self-use
-        raise IncorrectParameterError("There is no code review system associated with this VCS type")
+    def code_review(self):
+        return None
 
     def prepare_repository(self):
         raise NotImplementedError

--- a/universum/modules/vcs/base_vcs.py
+++ b/universum/modules/vcs/base_vcs.py
@@ -51,7 +51,7 @@ class BaseDownloadVcs(BaseVcs, HasErrorState):
     Base class for default CI build VCS drivers
     """
 
-    def code_review(self):
+    def code_review(self):  # pylint: disable=no-self-use
         return None
 
     def prepare_repository(self):


### PR DESCRIPTION
Fixed the check for error state in 'MainVcs’ module. If the check is implemented
for error state, as it was before, the code doesn’t try to construct the code
review module in case of any errors across the entire universum. As the result,
there is no check for errors in the parameters of the code review modules and
these errors are not reported to user.

Moved the check for code review and producing error from VCS drivers to the
'MainVcs’ module.

Fixed minor issue with unnecessary try..except block in 'Vcs’ module. In the
past the attempt to access missing vcs type parameter in module settings would
result in AttributeError exception. There were no other sources of this
exception in the code block. However, since there is an explicit check for the
vcs type setting, the try..except block is not needed anymore.
