### PR TITLE
refactor(nonci): rename default command to launch nonci

### DIFF
--- a/doc/args.rst
+++ b/doc/args.rst
@@ -35,9 +35,9 @@ via ``python3.7 -m universum``.
         | * -f='test 1:!unit test 1'    - run all steps with 'test 1' substring in their names except those
          containing 'unit test 1'
 
-    {create-config,poll,submit,nonci,github-handler} : @replace
+    {init,run,poll,submit,github-handler} : @replace
         | :doc:`universum init <init>`
+        | :doc:`universum run <nonci>`
         | :doc:`universum poll <args_poll>`
         | :doc:`universum submit <args_submit>`
-        | :doc:`universum nonci <args_nonci>`
         | :doc:`universum github-handler <args_github_handler>`

--- a/doc/nonci.rst
+++ b/doc/nonci.rst
@@ -1,7 +1,9 @@
 :orphan:
 
-Non-CI subcommand
--------------------
+.. TODO: update description after full ``universum run`` refactoring
+
+Run Universum locally (Non-CI mode)
+-----------------------------------
 
 The purpose of this mode is improving usability of 'Universum' on a local host PC.
 This mode is designed to use 'Universum' as a wrapper for a complex build system.
@@ -9,7 +11,7 @@ In particular such wrapper could help to resolve the following issues:
 
 - every build command run requires setting up a lot of input parameters
 - bash script is used to wrap build system like GNU Make
-- universum configs contain duplications of build system wrapper
+- :doc:`Universum configs <configuring>` contain duplications of build system wrapper
 
 
 The 'universum nonci' has the following differences from the regular mode:
@@ -17,11 +19,11 @@ The 'universum nonci' has the following differences from the regular mode:
 - report to code review system, such as 'GitHub' or 'Swarm', is disabled
 - version control is disabled
 - implemented removing of artifacts before build
-- 'Universum' works with sources 'in place', without copying
+- `Universum` works with sources 'in place', without copying
 
 
 .. argparse::
     :module: universum.__main__
     :func: define_arguments
     :prog: python3.7 -m universum
-    :path: nonci
+    :path: run

--- a/universum/__main__.py
+++ b/universum/__main__.py
@@ -24,7 +24,7 @@ def define_arguments() -> ModuleArgumentParser:
     define_arguments_recursive(Main, parser)
 
     subparsers = parser.add_subparsers(title="Additional commands",
-                                       metavar="{init,poll,submit,nonci,github-handler}",
+                                       metavar="{init,run,poll,submit,github-handler}",
                                        help="Use 'universum <subcommand> --help' for more info")
 
     def define_command(klass, command):
@@ -37,6 +37,7 @@ def define_arguments() -> ModuleArgumentParser:
     define_command(ConfigCreator, "init")
     define_command(Poll, "poll")
     define_command(Submit, "submit")
+    define_command(Nonci, "run")
     define_command(Nonci, "nonci")
     define_command(GithubHandler, "github-handler")
 

--- a/universum/config_creator.py
+++ b/universum/config_creator.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     print(configs.dump())
 """)
         self.out.log("To run with Universum, execute the following command:\n"
-                     "$ python3.7 -m universum nonci --launcher-config-path={}".format(config_name))
+                     "$ python3.7 -m universum run --launcher-config-path={}".format(config_name))
 
     def finalize(self) -> None:
         pass


### PR DESCRIPTION
Somehow it doesn't allow empty descriptions any more.