### PR TITLE
refactor: rename interface classes

### DIFF
--- a/configs.py
+++ b/configs.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
 env_name = "virtual_universe"
 python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
@@ -17,40 +17,42 @@ def pip_install(module_name):
     return "python -m pip --default-timeout=1200 install --progress-bar off -U " + module_name
 
 
-configs = Variations([dict(name="Update Docker images", command=["make", "images"]),
-                      dict(name="Update Pylint", command=[python, "-m", "pip", "install",
-                                                          "-U", "--user", "--progress-bar", "off", "pylint"]),
-                      dict(name="Create virtual environment", command=[python, "-m", "venv", env_name]),
+configs = Configuration([dict(name="Update Docker images", command=["make", "images"]),
+                         dict(name="Update Pylint", command=[python, "-m", "pip", "install",
+                                                             "-U", "--user", "--progress-bar", "off", "pylint"]),
+                         dict(name="Create virtual environment", command=[python, "-m", "venv", env_name]),
 
-                      dict(name="Install Universum for tests", artifacts="junit_results.xml",
-                           command=run_virtual(pip_install(".[test]"))),
-                      dict(name="Make", artifacts="doc/_build",
-                           command=run_virtual("make")),
-                      dict(name="Make tests", artifacts="htmlcov",
-                           command=run_virtual("export LANG=en_US.UTF-8; make test")),
+                         dict(name="Install Universum for tests", artifacts="junit_results.xml",
+                              command=run_virtual(pip_install(".[test]"))),
+                         dict(name="Make", artifacts="doc/_build",
+                              command=run_virtual("make")),
+                         dict(name="Make tests", artifacts="htmlcov",
+                              command=run_virtual("export LANG=en_US.UTF-8; make test")),
 
-                      dict(name="Run static pylint", code_report=True,
-                           command=[python, "-m", "universum.analyzers.pylint",
+                         dict(name="Run static pylint", code_report=True,
+                              command=[python, "-m", "universum.analyzers.pylint",
                                     f"--python-version={python_version}",
                                     "--rcfile=pylintrc", "--result-file=${CODE_REPORT_FILE}",
                                     "--files", "*.py", "universum/", "tests/"]),
-                      dict(name="Run static type checker", code_report=True,
-                           command=run_virtual("make mypy")),
+                         dict(name="Run static type checker", code_report=True,
+                              command=run_virtual("make mypy")),
 
-                      dict(name="Run Jenkins plugin Java tests",
-                           artifacts="universum_log_collapser/universum_log_collapser/target/surefire-reports/*.xml",
-                           command=["mvn", "-B", "package"], directory="universum_log_collapser/universum_log_collapser"),
-                      dict(name="Run Jenkins plugin CLI version",
-                           command=["mvn", "-B", "compile", "assembly:single"],
-                           artifacts="universum_log_collapser/universum_log_collapser/target/universum_log_collapser.hpi",
-                           directory="universum_log_collapser/universum_log_collapser"),
+                         dict(name="Run Jenkins plugin Java tests",
+                              artifacts="universum_log_collapser/universum_log_collapser/target/surefire-reports/*.xml",
+                              command=["mvn", "-B", "package"], directory="universum_log_collapser"
+                                                                          "/universum_log_collapser"),
+                         dict(name="Run Jenkins plugin CLI version",
+                              command=["mvn", "-B", "compile", "assembly:single"],
+                              artifacts="universum_log_collapser/universum_log_collapser/target"
+                                        "/universum_log_collapser.hpi",
+                              directory="universum_log_collapser/universum_log_collapser"),
 
-                      dict(name="Generate HTML for JavaScript tests",
-                           command=[python, "universum_log_collapser/e2e/universum_live_log_to_html.py"]),
-                      dict(name="Prepare Jenkins plugin JavaScript tests project",
-                           command=["npm", "install"], directory="universum_log_collapser/e2e"),
-                      dict(name="Run Jenkins plugin JavaScript tests",
-                           command=["npm", "test"], directory="universum_log_collapser/e2e")])
+                         dict(name="Generate HTML for JavaScript tests",
+                              command=[python, "universum_log_collapser/e2e/universum_live_log_to_html.py"]),
+                         dict(name="Prepare Jenkins plugin JavaScript tests project",
+                              command=["npm", "install"], directory="universum_log_collapser/e2e"),
+                         dict(name="Run Jenkins plugin JavaScript tests",
+                              command=["npm", "test"], directory="universum_log_collapser/e2e")])
 
 if __name__ == '__main__':
     print(configs.dump())

--- a/configs.py
+++ b/configs.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from universum.configuration_support import Configuration
+from universum.configuration_support import Variations
 
 env_name = "virtual_universe"
 python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
@@ -17,42 +17,40 @@ def pip_install(module_name):
     return "python -m pip --default-timeout=1200 install --progress-bar off -U " + module_name
 
 
-configs = Configuration([dict(name="Update Docker images", command=["make", "images"]),
-                         dict(name="Update Pylint", command=[python, "-m", "pip", "install",
-                                                             "-U", "--user", "--progress-bar", "off", "pylint"]),
-                         dict(name="Create virtual environment", command=[python, "-m", "venv", env_name]),
+configs = Variations([dict(name="Update Docker images", command=["make", "images"]),
+                      dict(name="Update Pylint", command=[python, "-m", "pip", "install",
+                                                          "-U", "--user", "--progress-bar", "off", "pylint"]),
+                      dict(name="Create virtual environment", command=[python, "-m", "venv", env_name]),
 
-                         dict(name="Install Universum for tests", artifacts="junit_results.xml",
-                              command=run_virtual(pip_install(".[test]"))),
-                         dict(name="Make", artifacts="doc/_build",
-                              command=run_virtual("make")),
-                         dict(name="Make tests", artifacts="htmlcov",
-                              command=run_virtual("export LANG=en_US.UTF-8; make test")),
+                      dict(name="Install Universum for tests", artifacts="junit_results.xml",
+                           command=run_virtual(pip_install(".[test]"))),
+                      dict(name="Make", artifacts="doc/_build",
+                           command=run_virtual("make")),
+                      dict(name="Make tests", artifacts="htmlcov",
+                           command=run_virtual("export LANG=en_US.UTF-8; make test")),
 
-                         dict(name="Run static pylint", code_report=True,
-                              command=[python, "-m", "universum.analyzers.pylint",
+                      dict(name="Run static pylint", code_report=True,
+                           command=[python, "-m", "universum.analyzers.pylint",
                                     f"--python-version={python_version}",
                                     "--rcfile=pylintrc", "--result-file=${CODE_REPORT_FILE}",
                                     "--files", "*.py", "universum/", "tests/"]),
-                         dict(name="Run static type checker", code_report=True,
-                              command=run_virtual("make mypy")),
+                      dict(name="Run static type checker", code_report=True,
+                           command=run_virtual("make mypy")),
 
-                         dict(name="Run Jenkins plugin Java tests",
-                              artifacts="universum_log_collapser/universum_log_collapser/target/surefire-reports/*.xml",
-                              command=["mvn", "-B", "package"], directory="universum_log_collapser"
-                                                                          "/universum_log_collapser"),
-                         dict(name="Run Jenkins plugin CLI version",
-                              command=["mvn", "-B", "compile", "assembly:single"],
-                              artifacts="universum_log_collapser/universum_log_collapser/target"
-                                        "/universum_log_collapser.hpi",
-                              directory="universum_log_collapser/universum_log_collapser"),
+                      dict(name="Run Jenkins plugin Java tests",
+                           artifacts="universum_log_collapser/universum_log_collapser/target/surefire-reports/*.xml",
+                           command=["mvn", "-B", "package"], directory="universum_log_collapser/universum_log_collapser"),
+                      dict(name="Run Jenkins plugin CLI version",
+                           command=["mvn", "-B", "compile", "assembly:single"],
+                           artifacts="universum_log_collapser/universum_log_collapser/target/universum_log_collapser.hpi",
+                           directory="universum_log_collapser/universum_log_collapser"),
 
-                         dict(name="Generate HTML for JavaScript tests",
-                              command=[python, "universum_log_collapser/e2e/universum_live_log_to_html.py"]),
-                         dict(name="Prepare Jenkins plugin JavaScript tests project",
-                              command=["npm", "install"], directory="universum_log_collapser/e2e"),
-                         dict(name="Run Jenkins plugin JavaScript tests",
-                              command=["npm", "test"], directory="universum_log_collapser/e2e")])
+                      dict(name="Generate HTML for JavaScript tests",
+                           command=[python, "universum_log_collapser/e2e/universum_live_log_to_html.py"]),
+                      dict(name="Prepare Jenkins plugin JavaScript tests project",
+                           command=["npm", "install"], directory="universum_log_collapser/e2e"),
+                      dict(name="Run Jenkins plugin JavaScript tests",
+                           command=["npm", "test"], directory="universum_log_collapser/e2e")])
 
 if __name__ == '__main__':
     print(configs.dump())

--- a/doc/code_report.rst
+++ b/doc/code_report.rst
@@ -40,9 +40,9 @@ Config example for ``universum.analyzers.pylint``:
 
 .. testcode::
 
-    from universum.configuration_support import Variations
+    from universum.configuration_support import Configuration
 
-    configs = Variations([dict(name="pylint", code_report=True, command=[
+    configs = Configuration([dict(name="pylint", code_report=True, command=[
         "{python}", "-m", "universum.analyzers.pylint", "--python-version", "2.7",
         "--result-file", "${CODE_REPORT_FILE}", "--files", "*.py", "examples/"
     ])])
@@ -77,9 +77,9 @@ Config example for ``universum.analyzers.svace``:
 
 .. testcode::
 
-    from universum.configuration_support import Variations
+    from universum.configuration_support import Configuration
 
-    configs = Variations([dict(name="svace", code_report=True, command=[
+    configs = Configuration([dict(name="svace", code_report=True, command=[
         "{python}", "-m", "universum.analyzers.svace", "--build-cmd", "make", "--lang", "CXX",
         "--result-file", "${CODE_REPORT_FILE}"
     ])])
@@ -115,9 +115,9 @@ Config example for ``universum.analyzers.uncrustify``:
 
 .. testcode::
 
-    from universum.configuration_support import Variations
+    from universum.configuration_support import Configuration
 
-    configs = Variations([dict(name="uncrustify", code_report=True, command=[
+    configs = Configuration([dict(name="uncrustify", code_report=True, command=[
         "{python}", "-m", "universum.analyzers.uncrustify",  "--files", "project_root_directory",
         "--cfg-file", "file_name.cfg", "--filter-regex", ".*//.(?:c|cpp)",
         "--result-file", "${CODE_REPORT_FILE}", "--output-directory", "uncrustify"

--- a/doc/configuring.rst
+++ b/doc/configuring.rst
@@ -144,12 +144,9 @@ See the following example configuration file:
 
     from universum.configuration_support import Configuration, get_project_root
 
-<<<<<<< HEAD
-    configs = Variations([dict(name="Run tests", directory="/home/scripts", command=["./run_tests.sh", "--directory", get_project_root()])])
-=======
+
     configs = Configuration([dict(name="Run tests", directory="/home/scripts",
-                               command=["./run_tests.sh", "--directory", get_project_root()])])
->>>>>>> 6a5de62... refactor: rename classes
+                                  command=["./run_tests.sh", "--directory", get_project_root()])])
 
 In this configuration a hypothetical external script `"run_tests.sh"` requires absolute path
 to project sources as an argument. The :func:`get_project_root` will pass the actual project root,
@@ -435,13 +432,8 @@ where the third will follow the second.
 Combining configurations
 ------------------------
 
-<<<<<<< HEAD
-The Variations class provides a way to generate a full testing scenario by simulating the
-combination of configurations.
-=======
 The :class:`Configuration` class provides a way to generate a full testing scenario by simulating the
 combination of different configurations (as in :class:`Configuration` instances).
->>>>>>> 6a5de62... refactor: rename classes
 
 For this class :class:`Configuration` has built-in ``+`` and ``*`` operators that allow creating
 configuration sets out of several :class:`Configuration` instances.

--- a/doc/configuring.rst
+++ b/doc/configuring.rst
@@ -55,7 +55,7 @@ Below is an example of the configuration file in its most basic form:
     configs = Configuration([dict(name="Build", command=["build.sh"])])
 
 This configuration file uses a :class:`Configuration` class from the :mod:`universum.configuration_support`
-module and describes exactly one `build step`_.
+module and describes exactly one build step.
 
 .. note::
 

--- a/doc/configuring.rst
+++ b/doc/configuring.rst
@@ -60,7 +60,7 @@ module and describes exactly one build step.
 .. note::
 
     Creating a :class:`Configuration` instance takes a list of dictionaries as an argument,
-    where every new list member describes a new `build step`_.
+    where every new list member describes a new build step.
 
 * The :mod:`universum.configuration_support` module provides several functions to be used by project configuration files
 * The `Universum` expects project configuration file to define global variable with

--- a/doc/configuring.rst
+++ b/doc/configuring.rst
@@ -50,10 +50,11 @@ Below is an example of the configuration file in its most basic form:
 
 .. testcode::
 
-    from universum.configuration_support import Variations
+    from universum.configuration_support import Configuration
 
-    configs = Variations([dict(name="Build", command=["build.sh"])])
+    configs = Configuration([dict(name="Build", command=["build.sh"])])
 
+<<<<<<< HEAD
 This configuration file uses a :class:`Variations` class
 from the :mod:`universum.configuration_support`
 module and defines one build configuration.
@@ -62,6 +63,15 @@ module and defines one build configuration.
 
     Creating a :class:`Variations` instance takes a list of dictionaries as an argument,
     where every new list member describes a new `project configuration`_.
+=======
+This configuration file uses a :class:`Configuration` class from the :mod:`universum.configuration_support`
+module and describes exactly one `build step`_.
+
+.. note::
+
+    Creating a :class:`Configuration` instance takes a list of dictionaries as an argument,
+    where every new list member describes a new `build step`_.
+>>>>>>> 6a5de62... refactor: rename classes
 
 * The :mod:`universum.configuration_support` module provides several functions to be used by project configuration files
 * The `Universum` expects project configuration file to define global variable with
@@ -98,9 +108,9 @@ using `directory` keyword:
 
 .. testcode::
 
-    from universum.configuration_support import Variations
+    from universum.configuration_support import Configuration
 
-    configs = Variations([dict(name="Make Special Module", directory="specialModule", command=["make"])])
+    configs = Configuration([dict(name="Make Special Module", directory="specialModule", command=["make"])])
 
 To use a `Makefile` located in `"specialModule"` directory without passing "-C specialModule/"
 arguments to ``make`` command, the launch directory is specified.
@@ -132,9 +142,14 @@ See the following example configuration file:
 
 .. testcode::
 
-    from universum.configuration_support import Variations, get_project_root
+    from universum.configuration_support import Configuration, get_project_root
 
+<<<<<<< HEAD
     configs = Variations([dict(name="Run tests", directory="/home/scripts", command=["./run_tests.sh", "--directory", get_project_root()])])
+=======
+    configs = Configuration([dict(name="Run tests", directory="/home/scripts",
+                               command=["./run_tests.sh", "--directory", get_project_root()])])
+>>>>>>> 6a5de62... refactor: rename classes
 
 In this configuration a hypothetical external script `"run_tests.sh"` requires absolute path
 to project sources as an argument. The :func:`get_project_root` will pass the actual project root,
@@ -152,11 +167,11 @@ Below is an example of the configuration file with three different configuration
 
 .. testcode::
 
-    from universum.configuration_support import Variations, get_project_root
+    from universum.configuration_support import Configuration, get_project_root
     import os.path
 
     test_path = os.path.join(get_project_root(), "out/tests")
-    configs = Variations([
+    configs = Configuration([
         dict(name="Make Special Module", command=["make", "-C", "SpecialModule/"], artifacts="out"),
         dict(name="Run internal tests", command=["scripts/run_tests.sh"]),
         dict(name="Run external tests", directory="/home/scripts", command=["run_tests.sh", "-d", test_path])
@@ -176,7 +191,7 @@ The example configuration file declares the following `Universum` run steps:
     :func:`os.path.join` function to avoid any possible errors on path joining.
 
 
-Common `Variations` keys
+Common `Configuration` keys
 ------------------------
 
 Each configuration description is a python dictionary with the following possible keys:
@@ -318,13 +333,13 @@ pass_tag, fail_tag
 
         #!/usr/bin/env {python}
 
-        from universum.configuration_support import Variations
+        from universum.configuration_support import Configuration
 
     .. testcode::
 
-        make = Variations([dict(name="Make ", command=["make"], pass_tag="pass_")])
+        make = Configuration([dict(name="Make ", command=["make"], pass_tag="pass_")])
 
-        target = Variations([
+        target = Configuration([
             dict(name="Linux", command=["--platform", "Linux"], pass_tag="Linux"),
             dict(name="Windows", command=["--platform", "Windows"], pass_tag="Windows")
         ])
@@ -357,10 +372,10 @@ pass_tag, fail_tag
 Dump configurations list
 ------------------------
 
-Class :class:`Variations` have a build-in function :meth:`~Variations.dump`, that processes the passed dictionaries
-and returns the list of all included configurations.
+Class :class:`Configuration` has a build-in function :meth:`~Configuration.dump`, that processes the passed dictionaries
+and returns the list of all included build steps.
 
-Below is an example of the configuration file that uses :meth:`~Variations.dump` function for debugging:
+Below is an example of the configuration file that uses :meth:`~Configuration.dump` function for debugging:
 
 .. testsetup::
 
@@ -374,11 +389,11 @@ Below is an example of the configuration file that uses :meth:`~Variations.dump`
 
     #!/usr/bin/env {python}
 
-    from universum.configuration_support import Variations, get_project_root
+    from universum.configuration_support import Configuration, get_project_root
     import os.path
 
     test_path = os.path.join(get_project_root(), "out/tests")
-    configs = Variations([
+    configs = Configuration([
         dict(name="Make Special Module", command=["make", "-C", "SpecialModule/"], artifacts="out"),
         dict(name="Run internal tests", command=["scripts/run_tests.sh"]),
         dict(name="Run external tests", directory="/home/scripts", command=["run_tests.sh", "-d", test_path])
@@ -420,11 +435,16 @@ where the third will follow the second.
 Combining configurations
 ------------------------
 
+<<<<<<< HEAD
 The Variations class provides a way to generate a full testing scenario by simulating the
 combination of configurations.
+=======
+The :class:`Configuration` class provides a way to generate a full testing scenario by simulating the
+combination of different configurations (as in :class:`Configuration` instances).
+>>>>>>> 6a5de62... refactor: rename classes
 
-For this class :class:`Variations` has built-in ``+`` and ``*`` operators that allow creating
-configuration sets out of several :class:`Variations` instances.
+For this class :class:`Configuration` has built-in ``+`` and ``*`` operators that allow creating
+configuration sets out of several :class:`Configuration` instances.
 
 
 Adding build configurations
@@ -436,10 +456,10 @@ See the following example:
 
     #!/usr/bin/env {python}
 
-    from universum.configuration_support import Variations
+    from universum.configuration_support import Configuration
 
-    one = Variations([dict(name="Make project", command=["make"])])
-    two = Variations([dict(name="Run tests", command=["run_tests.sh"])])
+    one = Configuration([dict(name="Make project", command=["make"])])
+    two = Configuration([dict(name="Run tests", command=["run_tests.sh"])])
 
     configs = one + two
 
@@ -475,7 +495,7 @@ Multiplying configuration by a constant is just an equivalent of multiple additi
 
 .. doctest::
 
-    >>> run = Variations([dict(name="Run tests", command=["run_tests.sh"])])
+    >>> run = Configuration([dict(name="Run tests", command=["run_tests.sh"])])
     >>> print (run * 2 == run + run)
     True
 
@@ -488,11 +508,11 @@ For example, this configuration file:
 
     #!/usr/bin/env {python}
 
-    from universum.configuration_support import Variations
+    from universum.configuration_support import Configuration
 
-    make = Variations([dict(name="Make ", command=["make"], artifacts="out")])
+    make = Configuration([dict(name="Make ", command=["make"], artifacts="out")])
 
-    target = Variations([dict(name="Platform A", command=["--platform", "A"]),
+    target = Configuration([dict(name="Platform A", command=["--platform", "A"]),
                          dict(name="Platform B", command=["--platform", "B"])])
 
     configs = make * target
@@ -536,15 +556,15 @@ can be combined in any required way. For example:
 
     #!/usr/bin/env {python}
 
-    from universum.configuration_support import Variations
+    from universum.configuration_support import Configuration
 
-    make = Variations([dict(name="Make ", command=["make"], artifacts="out")])
-    test = Variations([dict(name="Run tests for ", directory="/home/scripts", command=["run_tests.sh", "--all"])])
+    make = Configuration([dict(name="Make ", command=["make"], artifacts="out")])
+    test = Configuration([dict(name="Run tests for ", directory="/home/scripts", command=["run_tests.sh", "--all"])])
 
-    debug = Variations([dict(name=" - Release"),
+    debug = Configuration([dict(name=" - Release"),
                         dict(name=" - Debug", command=["-d"])])
 
-    target = Variations([dict(name="Platform A", command=["--platform", "A"]),
+    target = Configuration([dict(name="Platform A", command=["--platform", "A"]),
                          dict(name="Platform B", command=["--platform", "B"])])
 
     configs = make * target + test * target * debug

--- a/doc/configuring.rst
+++ b/doc/configuring.rst
@@ -54,16 +54,6 @@ Below is an example of the configuration file in its most basic form:
 
     configs = Configuration([dict(name="Build", command=["build.sh"])])
 
-<<<<<<< HEAD
-This configuration file uses a :class:`Variations` class
-from the :mod:`universum.configuration_support`
-module and defines one build configuration.
-
-.. note::
-
-    Creating a :class:`Variations` instance takes a list of dictionaries as an argument,
-    where every new list member describes a new `project configuration`_.
-=======
 This configuration file uses a :class:`Configuration` class from the :mod:`universum.configuration_support`
 module and describes exactly one `build step`_.
 
@@ -71,7 +61,6 @@ module and describes exactly one `build step`_.
 
     Creating a :class:`Configuration` instance takes a list of dictionaries as an argument,
     where every new list member describes a new `build step`_.
->>>>>>> 6a5de62... refactor: rename classes
 
 * The :mod:`universum.configuration_support` module provides several functions to be used by project configuration files
 * The `Universum` expects project configuration file to define global variable with

--- a/examples/basic_config.py
+++ b/examples/basic_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os.path
-from universum.configuration_support import Variations, get_project_root
+from universum.configuration_support import Configuration, get_project_root
 
 #
 # One way to specify path to the script: add full path to the command
@@ -9,21 +9,21 @@ from universum.configuration_support import Variations, get_project_root
 script_name = './basic_build_script.sh'
 script_path = os.path.abspath(os.path.join(get_project_root(), script_name))
 
-build32 = Variations([dict(name='Build ', command=[script_path], artifacts='out')])
+build32 = Configuration([dict(name='Build ', command=[script_path], artifacts='out')])
 
-platforms32 = Variations([dict(name='for platform A ', command=['--platform_a']),
-                          dict(name='for platform B ', command=['--platform_b'])])
+platforms32 = Configuration([dict(name='for platform A ', command=['--platform_a']),
+                             dict(name='for platform B ', command=['--platform_b'])])
 
-bits32 = Variations([dict(name='32 bits', command=['--32'], artifacts='/result*32.txt')])
+bits32 = Configuration([dict(name='32 bits', command=['--32'], artifacts='/result*32.txt')])
 configs = build32 * platforms32 * bits32
 
 
 #
 # Alternative way to specify path to the script: provide working directory in the 'directory' attribute of configuration
 #
-build64 = Variations([dict(name='Build ', directory=get_project_root(), command=[script_name], artifacts='out')])
-platforms64 = Variations([dict(name='for platform C ', command=['--platform_c'])])
-bits64 = Variations([dict(name='64 bits', command=['--64'])])
+build64 = Configuration([dict(name='Build ', directory=get_project_root(), command=[script_name], artifacts='out')])
+platforms64 = Configuration([dict(name='for platform C ', command=['--platform_c'])])
+bits64 = Configuration([dict(name='64 bits', command=['--64'])])
 configs += build64 * (platforms32 + platforms64) * bits64
 
 if __name__ == '__main__':

--- a/examples/configs.py
+++ b/examples/configs.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-not_script = Variations([dict(name='Not script', command=["not_run.sh"])])
+not_script = Configuration([dict(name='Not script', command=["not_run.sh"])])
 
-script = Variations([dict(command=["run.sh"], directory="examples")])
+script = Configuration([dict(command=["run.sh"], directory="examples")])
 
-step = Variations([dict(name='Step 1', critical=True), dict(name='Step 2')])
+step = Configuration([dict(name='Step 1', critical=True), dict(name='Step 2')])
 
-additional_substep = Variations([dict(name=', additional substep', command=["fail"], critical=False)])
+additional_substep = Configuration([dict(name=', additional substep', command=["fail"], critical=False)])
 
-substep = Variations([dict(name=', failed substep', command=["fail"], artrifacts="*.sh"),
-                      dict(name=', successful substep', command=["pass"], artifacts="*.txt")])
+substep = Configuration([dict(name=', failed substep', command=["fail"], artrifacts="*.sh"),
+                         dict(name=', successful substep', command=["pass"], artifacts="*.txt")])
 
 configs = not_script + script * step * (substep + additional_substep)
 

--- a/examples/configs_artifacts.py
+++ b/examples/configs_artifacts.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-mkdir = Variations([dict(name="Create directory", command=["mkdir", "-p"])])
-mkfile = Variations([dict(name="Create file", command=["touch"])])
-dirs1 = Variations([dict(name=" one/two{}/three".format(str(x)),
-                         command=["one/two{}/three".format(str(x))]) for x in range(0, 6)])
-files1 = Variations([dict(name=" one/two{}/three/file{}.txt".format(str(x), str(x)),
-                          command=["one/two{}/three/file{}.txt".format(str(x), str(x))])
-                     for x in range(0, 6)])
+mkdir = Configuration([dict(name="Create directory", command=["mkdir", "-p"])])
+mkfile = Configuration([dict(name="Create file", command=["touch"])])
+dirs1 = Configuration([dict(name=" one/two{}/three".format(str(x)),
+                            command=["one/two{}/three".format(str(x))]) for x in range(0, 6)])
+files1 = Configuration([dict(name=" one/two{}/three/file{}.txt".format(str(x), str(x)),
+                             command=["one/two{}/three/file{}.txt".format(str(x), str(x))])
+                        for x in range(0, 6)])
 
-dirs2 = Variations([dict(name=" one/three", command=["one/three"])])
-files2 = Variations([dict(name=" one/three/file.sh", command=["one/three/file.sh"])])
+dirs2 = Configuration([dict(name=" one/three", command=["one/three"])])
+files2 = Configuration([dict(name=" one/three/file.sh", command=["one/three/file.sh"])])
 
-artifacts = Variations([dict(name="Existing artifacts", artifacts="one/**/file*", report_artifacts="one/*"),
-                        dict(name="Missing artifacts", artifacts="something", report_artifacts="something_else")])
+artifacts = Configuration([dict(name="Existing artifacts", artifacts="one/**/file*", report_artifacts="one/*"),
+                           dict(name="Missing artifacts", artifacts="something", report_artifacts="something_else")])
 
 configs = mkdir * dirs1 + mkdir * dirs2 + mkfile * files1 + mkfile * files2 + artifacts
 

--- a/examples/configs_background.py
+++ b/examples/configs_background.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-background = Variations([dict(name="Background", background=True)])
-sleep = Variations([dict(name=' long step', command=["sleep", "1"])])
-multiply = Variations([dict(name="_1"), dict(name="_2"), dict(name="_3")])
-wait = Variations([dict(name='Step requiring background results',
-                        command=["run.sh", "pass"], finish_background=True)])
+background = Configuration([dict(name="Background", background=True)])
+sleep = Configuration([dict(name=' long step', command=["sleep", "1"])])
+multiply = Configuration([dict(name="_1"), dict(name="_2"), dict(name="_3")])
+wait = Configuration([dict(name='Step requiring background results',
+                           command=["run.sh", "pass"], finish_background=True)])
 
-script = Variations([dict(name=" unsuccessful step", command=["run.sh", "fail"])])
+script = Configuration([dict(name=" unsuccessful step", command=["run.sh", "fail"])])
 
 configs = background * (script + sleep * multiply) + wait + background * (sleep + script)
 

--- a/examples/configs_critical.py
+++ b/examples/configs_critical.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-not_script = Variations([dict(name='Not script', command=["not_run.sh"], critical=True)])
+not_script = Configuration([dict(name='Not script', command=["not_run.sh"], critical=True)])
 
-script = Variations([dict(command=["run.sh"])])
+script = Configuration([dict(command=["run.sh"])])
 
-step = Variations([dict(name='Step 1', critical=True), dict(name='Step 2')])
+step = Configuration([dict(name='Step 1', critical=True), dict(name='Step 2')])
 
-substep = Variations([dict(name=', failed substep', command=["fail"]),
-                      dict(name=', successful substep', command=["pass"])])
+substep = Configuration([dict(name=', failed substep', command=["fail"]),
+                         dict(name=', successful substep', command=["pass"])])
 
 configs = script * step * substep + not_script + script
 

--- a/examples/if_env_set_config.py
+++ b/examples/if_env_set_config.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
 script_name = './basic_build_script.sh'
 
-build = Variations([dict(name='Build ', command=[script_name], artifacts='out')])
+build = Configuration([dict(name='Build ', command=[script_name], artifacts='out')])
 
-platforms = Variations([dict(name='for platform A ', command=['--platform_a'], if_env_set="PLATFORM == A"),
-                        dict(name='for platform B ', command=['--platform_b'], if_env_set="PLATFORM == B")])
+platforms = Configuration([dict(name='for platform A ', command=['--platform_a'], if_env_set="PLATFORM == A"),
+                           dict(name='for platform B ', command=['--platform_b'], if_env_set="PLATFORM == B")])
 
-bits = Variations([dict(name='32 bits', command=['--32'], artifacts='/result*32.txt'),
-                   dict(name='64 bits', command=['--64'], if_env_set=" & IS_X64")])
+bits = Configuration([dict(name='32 bits', command=['--32'], artifacts='/result*32.txt'),
+                      dict(name='64 bits', command=['--64'], if_env_set=" & IS_X64")])
 
 # Will run every platform with a specified tool with '--32' flag
 # Will run same platforms with '--64' flag only if $IS_X64 variable is set (e.g. by "export IS_X64=true")

--- a/examples/minimal_config.py
+++ b/examples/minimal_config.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name='Build ', command=['build.sh'], artifacts='out')])
+configs = Configuration([dict(name='Build ', command=['build.sh'], artifacts='out')])
 
 if __name__ == '__main__':
     print(configs.dump())

--- a/tests/perforce_utils.py
+++ b/tests/perforce_utils.py
@@ -42,7 +42,7 @@ def is_p4_container_healthy(container, server_name, polling_start):
             continue
 
         rfc3339_time, text = log.split(" ", 1)
-        if not all(x in text for x in ["Started", server_name, "p4d service."]):
+        if not all(x in text for x in ["Started ", server_name, " p4d service."]):
             continue
 
         # check if "Started <server name> p4d service" is logged after we

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,10 +4,10 @@ from os import path
 from .utils import python
 
 config = f"""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Run script", artifacts="output.json",
-                           command=["bash", "-c", "{python()} -m universum api file-diff > output.json"])])
+configs = Configuration([dict(name="Run script", artifacts="output.json",
+                              command=["bash", "-c", "{python()} -m universum api file-diff > output.json"])])
 """
 
 

--- a/tests/test_check_if_env_set.py
+++ b/tests/test_check_if_env_set.py
@@ -4,7 +4,7 @@ import os
 from typing import Optional
 import pytest
 
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 from universum.modules.launcher import check_if_env_set
 
 
@@ -25,7 +25,7 @@ def setup_env_vars(env_vars: Optional[dict]):
 
 def check(if_env_set_key, env_vars: Optional[dict]):
     setup_env_vars(env_vars)
-    if_env_set_var = Variations([dict(if_env_set=if_env_set_key)])[0]
+    if_env_set_var = Configuration([dict(if_env_set=if_env_set_key)])[0]
     return check_if_env_set(if_env_set_var)
 
 
@@ -163,8 +163,8 @@ def test_if_env_set_quotes_and_quotes_in_env_var_value():
 ##########################################################################
 
 def test_if_env_set_not_in_config():
-    var = Variations([dict(code_report=True),
-                      dict(artifacts="htmlcov", command=["echo 123"], pass_tag="PASS")])
+    var = Configuration([dict(code_report=True),
+                         dict(artifacts="htmlcov", command=["echo 123"], pass_tag="PASS")])
     os.environ["VAR_1"] = "False"
     os.environ["VAR_2"] = ""
     for item in var:
@@ -177,8 +177,8 @@ def test_if_env_set_not_in_config():
 
 def assert_equal_multiplication(expected, env_vars: Optional[dict] = None):
     setup_env_vars(env_vars)
-    var1 = Variations([dict(if_env_set="VAR_1 == value_1"), dict(if_env_set="VAR_2 == value_2")])
-    var2 = Variations([dict(if_env_set=" && VAR_3 == value_3")])
+    var1 = Configuration([dict(if_env_set="VAR_1 == value_1"), dict(if_env_set="VAR_2 == value_2")])
+    var2 = Configuration([dict(if_env_set=" && VAR_3 == value_3")])
     configs = var1 * var2
     result = list(filter(check_if_env_set, configs.all()))
     assert expected == result

--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -19,9 +19,9 @@ def fixture_runner_with_pylint(docker_main):
 def get_config(args: List[str]):
     args = [f", '{arg}'" for arg in args]
     return inspect.cleandoc(f"""
-        from universum.configuration_support import Variations
+        from universum.configuration_support import Configuration
 
-        configs = Variations([dict(name="Run static pylint", code_report=True,
+        configs = Configuration([dict(name="Run static pylint", code_report=True,
             command=['{python()}', '-m', 'universum.analyzers.pylint'{''.join(args)}])])
     """)
 
@@ -53,9 +53,9 @@ def test_code_report(runner_with_pylint, args, tested_content, expected_log):
 
 def test_without_code_report_command(runner_with_pylint):
     log = runner_with_pylint.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Run usual command", command=["ls", "-la"])])
+configs = Configuration([dict(name="Run usual command", command=["ls", "-la"])])
     """)
     pattern = re.compile(f"({log_fail}|{log_success})")
     assert not pattern.findall(log)
@@ -91,9 +91,9 @@ def test_code_report_extended_arg_search(tmpdir, stdout_checker):
     tmpdir.join("source_file.py").write(source_code + '\n')
 
     config = f"""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Run static pylint", code_report=True, artifacts="${{CODE_REPORT_FILE}}", command=[
+configs = Configuration([dict(name="Run static pylint", code_report=True, artifacts="${{CODE_REPORT_FILE}}", command=[
     'bash', '-c', 'cd "{os.getcwd()}" && {python()} -m universum.analyzers.pylint --result-file="${{CODE_REPORT_FILE}}" \
                    --python-version {python_version()} --files {str(tmpdir.join("source_file.py"))}'])])
 """

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,9 +1,9 @@
 from .utils import python
 
 config = """
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
 """
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -17,29 +17,29 @@ def get_line_with_text(text, log):
 
 def test_minimal_execution(docker_main_and_nonci):
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
 """)
     assert docker_main_and_nonci.local.repo_file.basename in log
 
 
 def test_artifacts(docker_main):
     config = """
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-mkdir = Variations([dict(name="Create directory", command=["mkdir", "-p"])])
-mkfile = Variations([dict(name="Create file", command=["touch"])])
-dirs1 = Variations([dict(name=" one/two{}/three".format(str(x)),
+mkdir = Configuration([dict(name="Create directory", command=["mkdir", "-p"])])
+mkfile = Configuration([dict(name="Create file", command=["touch"])])
+dirs1 = Configuration([dict(name=" one/two{}/three".format(str(x)),
                          command=["one/two{}/three".format(str(x))]) for x in range(0, 6)])
-files1 = Variations([dict(name=" one/two{}/three/file{}.txt".format(str(x), str(x)),
+files1 = Configuration([dict(name=" one/two{}/three/file{}.txt".format(str(x), str(x)),
                           command=["one/two{}/three/file{}.txt".format(str(x), str(x))])
                      for x in range(0, 6)])
 
-dirs2 = Variations([dict(name=" one/three", command=["one/three"])])
-files2 = Variations([dict(name=" one/three/file.sh", command=["one/three/file.sh"])])
+dirs2 = Configuration([dict(name=" one/three", command=["one/three"])])
+files2 = Configuration([dict(name=" one/three/file.sh", command=["one/three/file.sh"])])
 
-artifacts = Variations([dict(name="Existing artifacts", artifacts="one/**/file*", report_artifacts="one/*"),
+artifacts = Configuration([dict(name="Existing artifacts", artifacts="one/**/file*", report_artifacts="one/*"),
                         dict(name="Missing artifacts", artifacts="something", report_artifacts="something_else")])
 
 configs = mkdir * dirs1 + mkdir * dirs2 + mkfile * files1 + mkfile * files2 + artifacts
@@ -56,15 +56,15 @@ configs = mkdir * dirs1 + mkdir * dirs2 + mkfile * files1 + mkfile * files2 + ar
 
 def test_background_steps(docker_main_and_nonci):
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-background = Variations([dict(name="Background", background=True)])
-sleep = Variations([dict(name=' long step', command=["sleep", "1"])])
-multiply = Variations([dict(name="_1"), dict(name="_2"), dict(name="_3")])
-wait = Variations([dict(name='Step requiring background results',
-                        command=["echo", "test passed"], finish_background=True)])
+background = Configuration([dict(name="Background", background=True)])
+sleep = Configuration([dict(name=' long step', command=["sleep", "1"])])
+multiply = Configuration([dict(name="_1"), dict(name="_2"), dict(name="_3")])
+wait = Configuration([dict(name='Step requiring background results',
+                      command=["echo", "test passed"], finish_background=True)])
 
-script = Variations([dict(name=" unsuccessful step", command=["ls", "non-existent-file"])])
+script = Configuration([dict(name=" unsuccessful step", command=["ls", "non-existent-file"])])
 
 configs = background * (script + sleep * multiply) + wait + background * (sleep + script)
 """)
@@ -74,11 +74,11 @@ configs = background * (script + sleep * multiply) + wait + background * (sleep 
     # Test background after failed foreground (regression)
     docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Bad step", command=["ls", "not_a_file"]),
-                      dict(name="Good bg step", command=["touch", "file"],
-                      background=True, artifacts="file")])
+configs = Configuration([dict(name="Bad step", command=["ls", "not_a_file"]),
+                         dict(name="Good bg step", command=["touch", "file"],
+                         background=True, artifacts="file")])
 """)
     assert "All ongoing background steps completed" in log
     assert os.path.exists(os.path.join(docker_main_and_nonci.artifact_dir, "file"))
@@ -86,19 +86,19 @@ configs = Variations([dict(name="Bad step", command=["ls", "not_a_file"]),
     # Test TC step failing
     docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Bad bg step", command=["ls", "not_a_file"], background=True)])
+configs = Configuration([dict(name="Bad bg step", command=["ls", "not_a_file"], background=True)])
 """, additional_parameters=" -ot tc")
     assert "##teamcity[buildProblem description" in log
 
     # Test multiple failing background steps
     docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Bad step 1", command=["ls", "not_a_file"], background=True),
-                      dict(name="Bad step 2", command=["ls", "not_a_file"], background=True)])
+configs = Configuration([dict(name="Bad step 1", command=["ls", "not_a_file"], background=True),
+                         dict(name="Bad step 2", command=["ls", "not_a_file"], background=True)])
 """)
     assert 'Failed' in get_line_with_text("Bad step 2 - ", log)
 
@@ -106,11 +106,11 @@ configs = Variations([dict(name="Bad step 1", command=["ls", "not_a_file"], back
 def test_critical_steps(docker_main_and_nonci):
     # Test linear
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Good step", command=["echo", "step succeeded"]),
-                      dict(name="Bad step", command=["ls", "not_a_file"], critical=True),
-                      dict(name="Extra step", command=["echo", "This shouldn't be in log."])])
+configs = Configuration([dict(name="Good step", command=["echo", "step succeeded"]),
+                         dict(name="Bad step", command=["ls", "not_a_file"], critical=True),
+                         dict(name="Extra step", command=["echo", "This shouldn't be in log."])])
 """)
     assert "Extra step skipped because of critical step failure" in log
     assert "This shouldn't be in log." not in log
@@ -118,15 +118,15 @@ configs = Variations([dict(name="Good step", command=["echo", "step succeeded"])
     # Test embedded: critical step, critical substep
     docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-upper = Variations([dict(name="Group 1"),
-                    dict(name="Group 2", critical=True),
-                    dict(name="Group 3")])
+upper = Configuration([dict(name="Group 1"),
+                       dict(name="Group 2", critical=True),
+                       dict(name="Group 3")])
 
-lower = Variations([dict(name=", step 1", command=["echo", "step succeeded"]),
-                    dict(name=", step 2", command=["ls", "not_a_file"], critical=True),
-                    dict(name=", step 3", command=["echo", "This shouldn't be in log."])])
+lower = Configuration([dict(name=", step 1", command=["echo", "step succeeded"]),
+                       dict(name=", step 2", command=["ls", "not_a_file"], critical=True),
+                       dict(name=", step 3", command=["echo", "This shouldn't be in log."])])
 
 configs = upper * lower
 """)
@@ -136,14 +136,14 @@ configs = upper * lower
     # Test embedded: critical step, non-critical substep
     docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-upper = Variations([dict(name="Group 1", critical=True),
-                    dict(name="Group 2")])
+upper = Configuration([dict(name="Group 1", critical=True),
+                       dict(name="Group 2")])
 
-lower = Variations([dict(name=", step 1", command=["echo", "step succeeded"]),
-                    dict(name=", step 2", command=["ls", "not_a_file"]),
-                    dict(name=", step 3", command=["echo", "This should be in log."])])
+lower = Configuration([dict(name=", step 1", command=["echo", "step succeeded"]),
+                       dict(name=", step 2", command=["ls", "not_a_file"]),
+                       dict(name=", step 3", command=["echo", "This should be in log."])])
 
 configs = upper * lower
 """)
@@ -153,40 +153,40 @@ configs = upper * lower
     # Test critical non-commands
     docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Group 1")])
+configs = Configuration([dict(name="Group 1")])
 
-configs *= Variations([dict(name=", step 1", command=["echo", "step succeeded"]),
-                       dict(name=", step 2", command=["this-is-not-a-command"], critical=True),
-                       dict(name=", step 3", command=["echo", "This shouldn't be in log."])])
+configs *= Configuration([dict(name=", step 1", command=["echo", "step succeeded"]),
+                          dict(name=", step 2", command=["this-is-not-a-command"], critical=True),
+                          dict(name=", step 3", command=["echo", "This shouldn't be in log."])])
 
-configs += Variations([dict(name="Linear non-command", command=["this-is-not-a-command"], critical=True),
-                       dict(name="Extra step", command=["echo", "This shouldn't be in log."])])
+configs += Configuration([dict(name="Linear non-command", command=["this-is-not-a-command"], critical=True),
+                          dict(name="Extra step", command=["echo", "This shouldn't be in log."])])
 """)
     assert "This shouldn't be in log." not in log
 
     # Test background
     docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-group = Variations([dict(name="Group")])
+group = Configuration([dict(name="Group")])
 
-subgroup1 = Variations([dict(name=" 1, step 1", command=["ls", "not_a_file"], background=True),
-                        dict(name=" 1, step 2", command=["echo", "This should be in log - 1"],
+subgroup1 = Configuration([dict(name=" 1, step 1", command=["ls", "not_a_file"], background=True),
+                           dict(name=" 1, step 2", command=["echo", "This should be in log - 1"],
                              finish_background=True)])
 
-subgroup2 = Variations([dict(name=" 2, step 1", command=["ls", "not_a_file"], critical=True,
-                             background=True),
-                        dict(name=" 2, step 2", command=["echo", "This should be in log - 2"])])
+subgroup2 = Configuration([dict(name=" 2, step 1", command=["ls", "not_a_file"], critical=True,
+                                background=True),
+                           dict(name=" 2, step 2", command=["echo", "This should be in log - 2"])])
 
-subgroup3 = Variations([dict(name=" 3, step 1", command=["echo", "This shouldn't be in log."],
-                             finish_background=True),
-                        dict(name=" 3, step 2", command=["echo", "This shouldn't be in log."])])
+subgroup3 = Configuration([dict(name=" 3, step 1", command=["echo", "This shouldn't be in log."],
+                                finish_background=True),
+                           dict(name=" 3, step 2", command=["echo", "This shouldn't be in log."])])
 
 configs = group * subgroup1 + group * subgroup2 + group * subgroup3
-configs += Variations([dict(name="Additional step", command=["echo", "This should be in log - 3"])])
+configs += Configuration([dict(name="Additional step", command=["echo", "This should be in log - 3"])])
 """)
     assert "This shouldn't be in log." not in log
     assert "This should be in log - 1" in log
@@ -196,18 +196,18 @@ configs += Variations([dict(name="Additional step", command=["echo", "This shoul
 
 def test_minimal_git(docker_main_with_vcs):
     log = docker_main_with_vcs.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
 """, vcs_type="git")
     assert docker_main_with_vcs.git.repo_file.basename in log
 
 
 def test_minimal_p4(docker_main_with_vcs):
     log = docker_main_with_vcs.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
 """, vcs_type="p4")
     assert docker_main_with_vcs.perforce.repo_file.basename in log
 
@@ -216,9 +216,9 @@ def test_p4_params(docker_main_with_vcs):
     p4 = docker_main_with_vcs.perforce.p4
     p4_file = docker_main_with_vcs.perforce.repo_file
     config = """
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["cat", "{}"])])
+configs = Configuration([dict(name="Test configuration", command=["cat", "{}"])])
 """.format(p4_file.basename)
 
     # Prepare SYNC_CHANGELIST
@@ -277,9 +277,9 @@ def empty_required_params_ids(param):
 def test_empty_required_params(docker_main_with_vcs, url_error_expected, parameters, env):
     url_error = "URL of the Swarm server is not specified"
     config = """
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
 """
 
     log = docker_main_with_vcs.run(config, vcs_type="p4", expected_to_fail=True,
@@ -298,21 +298,21 @@ echo ${SPECIAL_TESTING_VARIABLE}
     script.chmod(0o777)
 
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["script.sh"],
-                           environment={"SPECIAL_TESTING_VARIABLE": "This string should be in log"})])
+configs = Configuration([dict(name="Test configuration", command=["script.sh"],
+                              environment={"SPECIAL_TESTING_VARIABLE": "This string should be in log"})])
 """)
     assert "This string should be in log" in log
 
     docker_main_and_nonci.clean_artifacts()
     log = docker_main_and_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-upper = Variations([dict(name="Test configuration",
-                         environment={"SPECIAL_TESTING_VARIABLE": "This string should be in log"})])
-lower = Variations([dict(name=" 1", command=["script.sh"], environment={"OTHER_VARIABLE": "Something"}),
-                    dict(name=" 2", command=["ls", "-la"])])
+upper = Configuration([dict(name="Test configuration",
+                            environment={"SPECIAL_TESTING_VARIABLE": "This string should be in log"})])
+lower = Configuration([dict(name=" 1", command=["script.sh"], environment={"OTHER_VARIABLE": "Something"}),
+                       dict(name=" 2", command=["ls", "-la"])])
 configs = upper * lower
 """)
     assert "This string should be in log" in log
@@ -321,9 +321,9 @@ configs = upper * lower
 @pytest.mark.parametrize("terminate_type", [signal.SIGINT, signal.SIGTERM], ids=["interrupt", "terminate"])
 def test_abort(local_sources, tmpdir, terminate_type):
     config = """
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Long step", command=["sleep", "10"])]) * 5
+configs = Configuration([dict(name="Long step", command=["sleep", "10"])]) * 5
 """
     config_file = tmpdir.join("configs.py")
     config_file.write(config)

--- a/tests/test_nonci.py
+++ b/tests/test_nonci.py
@@ -1,12 +1,12 @@
 config = """
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="artifact check",
-                           command=["bash", "-c", '''cat {}/test_nonci.txt''']),
+configs = Configuration([dict(name="artifact check",
+                              command=["bash", "-c", '''cat {}/test_nonci.txt''']),
 #                                                    ^ this helps to check artifact is deleted before launch 
 
-                      dict(name="test_step", artifacts="test_nonci.txt",
-                           command=["bash", "-c", '''echo "pwd:[$(pwd)]" && echo "test nonci" > test_nonci.txt'''])])
+                         dict(name="test_step", artifacts="test_nonci.txt",
+                              command=["bash", "-c", '''echo "pwd:[$(pwd)]" && echo "test nonci" > test_nonci.txt'''])])
 #                                                    ^ this helps to check the path is not changed
 """
 
@@ -54,10 +54,10 @@ def test_launcher_output(docker_nonci):
 
     # second call of universum must not contain previous step log
     docker_nonci.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="test_step",
-                           command=["bash", "-c", '''echo "Separate run"'''])])
+configs = Configuration([dict(name="test_step",
+                              command=["bash", "-c", '''echo "Separate run"'''])])
 """, additional_parameters='-lo file', workdir=cwd)
 
     second_run_step_log = docker_nonci.environment.assert_successful_execution(

--- a/tests/test_p4_exception_handling.py
+++ b/tests/test_p4_exception_handling.py
@@ -16,10 +16,10 @@ def test_p4_forbidden_local_revert(perforce_environment, stdout_checker):
     p4_file = perforce_environment.repo_file
 
     config = """
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Restrict changes", command=["chmod", "-R", "555", "."]),
-                      dict(name="Check", command=["ls", "-la"])])
+configs = Configuration([dict(name="Restrict changes", command=["chmod", "-R", "555", "."]),
+                         dict(name="Check", command=["ls", "-la"])])
 """
     p4.run_edit(perforce_environment.depot)
     p4_file.write(config)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -26,9 +26,9 @@ def test_clean_sources_exceptions(tmpdir):
     # Check failure with temp dir deleted by the launched project
     env.settings.LocalMainVcs.source_dir = str(tmpdir)
     env.configs_file.write("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["bash", "-c", "rm -rf {}"])])
+configs = Configuration([dict(name="Test configuration", command=["bash", "-c", "rm -rf {}"])])
 """.format(env.settings.ProjectDirectory.project_root))
 
     __main__.run(env.settings)
@@ -50,9 +50,9 @@ def test_p4_multiple_spaces_in_mappings(perforce_workspace, tmpdir):
 def test_non_utf8_environment(docker_main):
     # POSIX has no 'UTF-8' in it's name, but supports Unicode
     output = docker_main.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
 """, vcs_type="none", environment=['LANG=POSIX', 'LC_ALL=POSIX'])
     assert "\u2514" in output
 
@@ -62,8 +62,8 @@ configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
     docker_main.environment.assert_successful_execution('locale-gen --purge en_US')
     docker_main.environment.assert_successful_execution('update-locale LANG=en_US')
     output = docker_main.run("""
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
 """, vcs_type="none", environment=['LANG=en_US', 'LC_ALL=en_US'])
     assert "\u2514" not in output

--- a/tests/test_run_steps_filter.py
+++ b/tests/test_run_steps_filter.py
@@ -1,10 +1,10 @@
 import pytest
 
 config = """
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
 def step(name, cmd=False):
-    return Variations([dict(name=name, command=[] if not cmd else ["bash", "-c", '''echo "run step"'''])])
+    return Configuration([dict(name=name, command=[] if not cmd else ["bash", "-c", '''echo "run step"'''])])
 
 configs = step('parent 1 ') * (step('step 1', True) + step('step 2', True))
 configs += step('parent 2 ') * (step('step 1', True) + step('step 2', True))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,9 +88,9 @@ def create_empty_settings(test_type):
 
 
 simple_test_config = """
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
 """
 
 

--- a/universum/config_creator.py
+++ b/universum/config_creator.py
@@ -22,9 +22,9 @@ class ConfigCreator(Module):
         config = Path(config_name)
         config.write_text("""#!/usr/bin/env {}
 
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
-configs = Variations([dict(name='Show directory contents', command=['ls', '-la']),
+configs = Configuration([dict(name='Show directory contents', command=['ls', '-la']),
                       dict(name='Print a line', command=['bash', '-c', 'echo Hello world'])])
 
 if __name__ == '__main__':

--- a/universum/configuration_support.py
+++ b/universum/configuration_support.py
@@ -15,7 +15,6 @@ __all__ = [
 class ProjectConfiguration:
     """
     ProjectConfiguration is a collection of configurable project-specific data needed for Universum operations.
-    Legacy constructor supports dictionary data, but for static type checking please use new explicit constructor.
     """
 
     # pylint: disable-msg=too-many-locals
@@ -37,8 +36,9 @@ class ProjectConfiguration:
                  **kwargs) -> None:
         """
         All params supplied via named attributed shall be  type-checked for safety. Clients may provide custom
-        parameters in kwargs - these parameters will be stored internally in '_extras' dict and can be retrieved by
+        parameters in kwargs - these parameters will be stored internally in `_extras` `dict` and can be retrieved by
         indexing.
+        
         >>> ProjectConfiguration(foo='bar')
         {'foo': 'bar'}
         >>> cfg = ProjectConfiguration(name='foo', command=['1', '2', '3'], _extras={'_extras': 'test', 'bool': True})
@@ -70,10 +70,10 @@ class ProjectConfiguration:
 
     def __repr__(self) -> str:
         """
-        This function simulates dict-like representation for string output. This is useful when printing contents of
+        This function simulates `dict`-like representation for string output. This is useful when printing contents of
         :class:`Variations` objects, as internally they wrap a list of :class:`ProjectConfiguration` objects
 
-        :return: dict-like string
+        :return: a `dict`-like string
 
         >>> cfg = ProjectConfiguration(name='foo', command=['bar'], my_var='baz')
         >>> repr(cfg)
@@ -87,10 +87,10 @@ class ProjectConfiguration:
 
     def __eq__(self, other: Any) -> bool:
         """
-        This functions simulates dict-like legacy comparison
+        This functions simulates `dict`-like check for match
 
-        :param other: dict to compare values, or :class:`ProjectConfiguration` object to check equality
-        :return: 'True' if 'other' matches
+        :param other: `dict` to compare values, or :class:`ProjectConfiguration` object to check equality
+        :return: `True` if `other` matches
 
         >>> cfg1 = ProjectConfiguration(name='foo', my_var='bar')
         >>> cfg2 = ProjectConfiguration(name='foo', my_var='bar')
@@ -123,7 +123,7 @@ class ProjectConfiguration:
 
     def __getitem__(self, item: str) -> Optional[str]:
         """
-        This functions simulates dict-like legacy read access
+        This functions simulates `dict`-like legacy read access
 
         :param item: client-defined item
         :return: client-defined value
@@ -142,7 +142,7 @@ class ProjectConfiguration:
 
     def __setitem__(self, key: str, value: Any) -> None:
         """
-        This functions simulates dict-like legacy write access
+        This functions simulates `dict`-like legacy write access
 
         :param key: client-defined key
         :param value: client-defined value
@@ -177,7 +177,7 @@ class ProjectConfiguration:
     def __add__(self, other: 'ProjectConfiguration') -> 'ProjectConfiguration':
         """
         This functions defines operator ``+`` for :class:`ProjectConfiguration` class objects by
-        concatenating strings and contents of dictionaries. Note that 'critical' attribute is not merged.
+        concatenating strings and contents of dictionaries. Note that `critical` attribute is not merged.
 
         :param other: `ProjectConfiguration` object
         :return: new `ProjectConfiguration` object, including all attributes from both `self` and `other` objects
@@ -209,8 +209,8 @@ class ProjectConfiguration:
         """
         Replace instances of a string, used for pseudo-variables
 
-        :param from_string: string to replace, e.g. ${CODE_REPORT_FILE}
-        :param to_string: value to put in place of 'from_string'
+        :param from_string: string to replace, e.g. `${CODE_REPORT_FILE}`
+        :param to_string: value to put in place of `from_string`
 
         >>> cfg = ProjectConfiguration(name='foo test', command=['foo', 'baz', 'foobar'], \
         myvar1='foo', myvar2='bar', myvar3=1)
@@ -235,7 +235,7 @@ class ProjectConfiguration:
         """
         Concatenates components of a command into one element
 
-        :return: 'True', if any of the command components have space inside
+        :return: `True`, if any of the command components have space inside
 
         >>> cfg = ProjectConfiguration(name='stringify test', command=['foo', 'bar', '--baz'])
         >>> cfg.stringify_command()
@@ -357,9 +357,10 @@ class Variations:
 
     def __eq__(self, other: Any) -> bool:
         """
+        This function checks wrapped configurations for match
 
         :param other: :class:`Variations` object or list of :class:`ProjectConfiguration` objects
-        :return: 'True' if stored configurations match
+        :return: `True` if stored configurations match
 
         >>> l = [{'name': 'foo', 'critical': True}, {'name': 'bar', 'myvar': 'baz'}]
         >>> v1 = Variations(l)
@@ -392,7 +393,7 @@ class Variations:
         """
         This function defines truthiness of :class:`Variations` object
 
-        :return: 'True' if :class:`Variations` class object is empty
+        :return: `True` if :class:`Variations` class object is empty
 
         >>> v1 = Variations()
         >>> bool(v1)

--- a/universum/configuration_support.py
+++ b/universum/configuration_support.py
@@ -38,7 +38,7 @@ class ProjectConfiguration:
         All params supplied via named attributed shall be  type-checked for safety. Clients may provide custom
         parameters in kwargs - these parameters will be stored internally in `_extras` `dict` and can be retrieved by
         indexing.
-        
+
         >>> ProjectConfiguration(foo='bar')
         {'foo': 'bar'}
         >>> cfg = ProjectConfiguration(name='foo', command=['1', '2', '3'], _extras={'_extras': 'test', 'bool': True})

--- a/universum/main.py
+++ b/universum/main.py
@@ -5,7 +5,7 @@ from .lib.gravity import Dependency
 from .lib.module_arguments import ModuleArgumentParser
 from .modules import vcs, artifact_collector, reporter, launcher, code_report_collector
 from .modules.output import HasOutput
-from .configuration_support import Variations
+from .configuration_support import Configuration
 
 
 __all__ = ["Main"]
@@ -70,8 +70,8 @@ class Main(HasOutput):
                 raise SilentAbortException(application_exit_code=0)
 
         self.vcs.prepare_repository()
-        project_configs: Variations = self.launcher.process_project_configs()
-        afterall_configs: Variations = self.code_report_collector.prepare_environment(project_configs)
+        project_configs: Configuration = self.launcher.process_project_configs()
+        afterall_configs: Configuration = self.code_report_collector.prepare_environment(project_configs)
         self.artifacts.set_and_clean_artifacts(project_configs)
 
         self.reporter.report_build_started()

--- a/universum/modules/artifact_collector.py
+++ b/universum/modules/artifact_collector.py
@@ -9,7 +9,7 @@ import zipfile
 
 import glob2
 
-from ..configuration_support import ProjectConfiguration, Variations
+from ..configuration_support import Configuration
 from ..lib.ci_exception import CriticalCiException, CiException
 from ..lib.gravity import Dependency
 from ..lib.utils import make_block
@@ -155,7 +155,7 @@ class ArtifactCollector(ProjectDirectory, HasOutput, HasStructure):
         return new_artifact_list
 
     @make_block("Preprocessing artifact lists")
-    def set_and_clean_artifacts(self, project_configs: Variations, ignore_existing_artifacts: bool = False) -> None:
+    def set_and_clean_artifacts(self, project_configs: Configuration, ignore_existing_artifacts: bool = False) -> None:
         artifact_list = []
         report_artifact_list = []
         for configuration in project_configs.all():

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -4,7 +4,7 @@ import os
 from copy import deepcopy
 from typing import cast, Dict, List, Optional, TextIO, Tuple
 
-from ..configuration_support import Variations, ProjectConfiguration
+from ..configuration_support import Configuration, Step
 from .output import HasOutput
 from .project_directory import ProjectDirectory
 from . import artifact_collector, reporter
@@ -25,9 +25,9 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
         self.report_path: str = ""
         self.repo_diff: Optional[List[Tuple[Optional[str], Optional[str], Optional[str]]]]
 
-    def prepare_environment(self, project_config_variations: Variations) -> Variations:
-        afterall_steps: Variations = Variations()
-        for item in project_config_variations.configs:
+    def prepare_environment(self, project_config: Configuration) -> Configuration:
+        afterall_steps: Configuration = Configuration()
+        for item in project_config.configs:
             if not item.code_report:
                 continue
             if not self.report_path:

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -351,8 +351,8 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
         sys.path.append(os.path.join(os.path.dirname(config_path)))
 
         try:
-            with open(config_path) as config:
-                exec(config.read(), config_globals)  # pylint: disable=exec-used
+            with open(config_path) as config_file:
+                exec(config_file.read(), config_globals)  # pylint: disable=exec-used
             self.source_project_configs = config_globals["configs"]
             dump_file: TextIO = self.artifacts.create_text_file("CONFIGS_DUMP.txt")
             dump_file.write(self.source_project_configs.dump())

--- a/universum_log_collapser/e2e/universum_config/configs.py
+++ b/universum_log_collapser/e2e/universum_config/configs.py
@@ -1,12 +1,12 @@
-from universum.configuration_support import Variations
+from universum.configuration_support import Configuration
 
 
-one = Variations([{'name': 'one', 'command': ['echo', 'one']}])
+one = Configuration([{'name': 'one', 'command': ['echo', 'one']}])
 
-two = Variations([{'name': 'two'}])
-two_one = Variations([{'name': '_one', 'command': ['./universum_config/sleep_and_fail.sh']}])
-two_two = Variations([{'name': '_two', 'command': ['./universum_config/large_output_and_success.sh']}])
+two = Configuration([{'name': 'two'}])
+two_one = Configuration([{'name': '_one', 'command': ['./universum_config/sleep_and_fail.sh']}])
+two_two = Configuration([{'name': '_two', 'command': ['./universum_config/large_output_and_success.sh']}])
 
-three = Variations([{'name': 'three', 'command': ['./universum_config/fail.sh']}])
+three = Configuration([{'name': 'three', 'command': ['./universum_config/fail.sh']}])
 
 configs = one + two * (two_one + two_two) + three


### PR DESCRIPTION
Variations and ProjectConfiguration names are misleading and confusing. 
Variations is a Configuration, which can be added or multiplied with other
Configurations, while ProjectConfiguration is just a description of a single
step. Since there is a conflict with existing Step class, that class has been
renamed too.

The names have been changed as follows:
Step -> RunningStep
ProjectConfiguration -> Step
Variations -> Configuration