### PR TITLE
fix(p4): make exception handling more user-friendly

### DIFF
--- a/tests/test_p4_exception_handling.py
+++ b/tests/test_p4_exception_handling.py
@@ -85,3 +85,26 @@ def test_p4_print_exception_in_finalize(perforce_environment, stdout_checker):
     stdout_checker.assert_has_calls_with_param(
         "Errors during command execution( \"p4 client -d {}\" )".format(perforce_environment.client_name))
     stdout_checker.assert_has_calls_with_param("[Errno 2] No such file or directory")
+
+
+def test_p4_print_exception_in_sync(perforce_environment, stdout_checker):
+    settings = perforce_environment.settings
+    settings.PerforceMainVcs.sync_cls = "123,456"
+    result = __main__.run(settings)
+
+    assert result == 1
+    stdout_checker.assert_has_calls_with_param("Something went wrong")
+    stdout_checker.assert_has_calls_with_param("123,456")
+
+
+def test_p4_print_exception_wrong_shelve(perforce_environment, stdout_checker):
+    cl = perforce_environment.make_a_change()
+
+    settings = perforce_environment.settings
+    settings.PerforceMainVcs.shelve_cls = [cl]
+    result = __main__.run(settings)
+
+    assert result == 1
+    stdout_checker.assert_has_calls_with_param(
+        "Errors during command execution( \"p4 unshelve -s {} -f\" )".format(cl))
+    stdout_checker.assert_has_calls_with_param(f"[Error]: 'Change {cl} is already committed.'")

--- a/tests/test_p4_exception_handling.py
+++ b/tests/test_p4_exception_handling.py
@@ -104,6 +104,7 @@ def test_p4_print_exception_wrong_shelve(perforce_environment, stdout_checker):
     settings.PerforceMainVcs.shelve_cls = [cl]
     result = __main__.run(settings)
 
+    # This is not the 'already commited' case of Swarm review, so it actually should fail
     assert result == 1
     stdout_checker.assert_has_calls_with_param(
         "Errors during command execution( \"p4 unshelve -s {} -f\" )".format(cl))

--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -21,6 +21,7 @@ from . import base_vcs
 from .swarm import Swarm
 
 __all__ = [
+
     "PerforceMainVcs",
     "PerforcePollVcs",
     "PerforceSubmitVcs",
@@ -440,7 +441,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
                 self.out.log("CL already committed")
                 self.out.report_build_status("CL already committed")
                 self.swarm = None
-                raise SilentAbortException(application_exit_code=0) from e
+                raise SilentAbortException(application_exit_code=0) from e  # This scenario does not fail build
             raise
         return result
 

--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -21,7 +21,6 @@ from . import base_vcs
 from .swarm import Swarm
 
 __all__ = [
-
     "PerforceMainVcs",
     "PerforcePollVcs",
     "PerforceSubmitVcs",

--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -343,17 +343,16 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
             for depot in self.depots:
                 depot["cl"] = None
 
-            try:
-                for entry in self.sync_cls:
-                    splat_entry = entry.split("@")
-                    # Remove identical depot entries, mostly for aesthetic reasons
-                    for index, depot in enumerate(self.depots):
-                        if splat_entry[0] == depot["path"]:
-                            self.depots.pop(index)
-                    self.depots.append({"path": splat_entry[0], "cl": splat_entry[1]})
-            except IndexError:
-                text = f"Something went wrong when processing sync CL parameter ('{self.settings.sync_cls}')"
-                raise CriticalCiException(text)
+            for entry in self.sync_cls:
+                splat_entry = entry.split("@")
+                if len(splat_entry) != 2 or not all(splat_entry):
+                    text = f"Something went wrong when processing sync CL parameter ('{self.settings.sync_cls}')"
+                    raise CriticalCiException(text)
+                # Remove identical depot entries, mostly for aesthetic reasons
+                for index, depot in enumerate(self.depots):
+                    if splat_entry[0] == depot["path"]:
+                        self.depots.pop(index)
+                self.depots.append({"path": splat_entry[0], "cl": splat_entry[1]})
 
         # Retrieve list of shelved CLs from Swarm and "classic" environment variables
         cls = []

--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -342,13 +342,17 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
             for depot in self.depots:
                 depot["cl"] = None
 
-            for entry in self.sync_cls:
-                splat_entry = entry.split("@")
-                # Remove identical depot entries, mostly for aesthetic reasons
-                for index, depot in enumerate(self.depots):
-                    if splat_entry[0] == depot["path"]:
-                        self.depots.pop(index)
-                self.depots.append({"path": splat_entry[0], "cl": splat_entry[1]})
+            try:
+                for entry in self.sync_cls:
+                    splat_entry = entry.split("@")
+                    # Remove identical depot entries, mostly for aesthetic reasons
+                    for index, depot in enumerate(self.depots):
+                        if splat_entry[0] == depot["path"]:
+                            self.depots.pop(index)
+                    self.depots.append({"path": splat_entry[0], "cl": splat_entry[1]})
+            except IndexError:
+                text = f"Something went wrong when processing sync CL parameter ('{self.settings.sync_cls}')"
+                raise CriticalCiException(text)
 
         # Retrieve list of shelved CLs from Swarm and "classic" environment variables
         cls = []
@@ -437,7 +441,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
                 self.out.report_build_status("CL already committed")
                 self.swarm = None
                 raise SilentAbortException(application_exit_code=0) from e
-            raise P4Exception from e
+            raise
         return result
 
     @make_block("Unshelving")


### PR DESCRIPTION
Resolves #545
First test (and according fix) faces situation of SYNC_CLS variable containing comma, but not containing '@' delimiter.
Second test faces wrong P4Exception re-raise on non-expected errors.