### PR TITLE
fix(test): create-config test interfering with actual config

### DIFF
--- a/tests/test_create_config.py
+++ b/tests/test_create_config.py
@@ -6,15 +6,14 @@ from .utils import python
 
 
 def test_create_config(tmpdir):
-    my_env = os.environ.copy()
-    my_env["PYTHONPATH"] = os.getcwd()
+    test_environment = dict(os.environ, PYTHONPATH=os.getcwd())
     result = subprocess.run([python(), "-m", "universum", "init"],
-                            capture_output=True, check=True, cwd=tmpdir, env=my_env)
+                            capture_output=True, check=True, cwd=tmpdir, env=test_environment)
     new_command = ''
     for line in result.stdout.splitlines():
         if line.startswith(b'$ '):           # result.stdout is a byte string
             new_command = line.lstrip(b'$ ')
-    new_result = subprocess.run(new_command.split(), capture_output=True, check=True, cwd=tmpdir, env=my_env)
+    new_result = subprocess.run(new_command.split(), capture_output=True, check=True, cwd=tmpdir, env=test_environment)
     Path(tmpdir, ".universum.py").unlink()
     artifacts = Path(tmpdir, "artifacts")
     artifacts.joinpath("CONFIGS_DUMP.txt").unlink()

--- a/tests/test_create_config.py
+++ b/tests/test_create_config.py
@@ -4,15 +4,15 @@ import subprocess
 from .utils import python
 
 
-def test_create_config():
-    result = subprocess.run([python(), "-m", "universum", "init"], capture_output=True, check=True)
+def test_create_config(tmpdir):
+    result = subprocess.run([python(), "-m", "universum", "init"], capture_output=True, check=True, cwd=tmpdir)
     new_command = ''
     for line in result.stdout.splitlines():
         if line.startswith(b'$ '):           # result.stdout is a byte string
             new_command = line.lstrip(b'$ ')
-    new_result = subprocess.run(new_command.split(), capture_output=True, check=True)
-    Path(".universum.py").unlink()
-    artifacts = Path("artifacts")
+    new_result = subprocess.run(new_command.split(), capture_output=True, check=True, cwd=tmpdir)
+    Path(tmpdir, ".universum.py").unlink()
+    artifacts = Path(tmpdir, "artifacts")
     artifacts.joinpath("CONFIGS_DUMP.txt").unlink()
     artifacts.rmdir()
     assert 'Hello world' in str(new_result.stdout)

--- a/tests/test_create_config.py
+++ b/tests/test_create_config.py
@@ -1,16 +1,20 @@
 from pathlib import Path
+import os
 import subprocess
 
 from .utils import python
 
 
 def test_create_config(tmpdir):
-    result = subprocess.run([python(), "-m", "universum", "init"], capture_output=True, check=True, cwd=tmpdir)
+    my_env = os.environ.copy()
+    my_env["PYTHONPATH"] = os.getcwd()
+    result = subprocess.run([python(), "-m", "universum", "init"],
+                            capture_output=True, check=True, cwd=tmpdir, env=my_env)
     new_command = ''
     for line in result.stdout.splitlines():
         if line.startswith(b'$ '):           # result.stdout is a byte string
             new_command = line.lstrip(b'$ ')
-    new_result = subprocess.run(new_command.split(), capture_output=True, check=True, cwd=tmpdir)
+    new_result = subprocess.run(new_command.split(), capture_output=True, check=True, cwd=tmpdir, env=my_env)
     Path(tmpdir, ".universum.py").unlink()
     artifacts = Path(tmpdir, "artifacts")
     artifacts.joinpath("CONFIGS_DUMP.txt").unlink()

--- a/tests/test_create_config.py
+++ b/tests/test_create_config.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import os
 import subprocess
 
@@ -6,16 +5,11 @@ from .utils import python
 
 
 def test_create_config(tmpdir):
-    test_environment = dict(os.environ, PYTHONPATH=os.getcwd())
-    result = subprocess.run([python(), "-m", "universum", "init"],
-                            capture_output=True, check=True, cwd=tmpdir, env=test_environment)
+    launch_parameters = dict(capture_output=True, check=True, cwd=tmpdir, env=dict(os.environ, PYTHONPATH=os.getcwd()))
+    result = subprocess.run([python(), "-m", "universum", "init"], **launch_parameters)
     new_command = ''
     for line in result.stdout.splitlines():
         if line.startswith(b'$ '):           # result.stdout is a byte string
             new_command = line.lstrip(b'$ ')
-    new_result = subprocess.run(new_command.split(), capture_output=True, check=True, cwd=tmpdir, env=test_environment)
-    Path(tmpdir, ".universum.py").unlink()
-    artifacts = Path(tmpdir, "artifacts")
-    artifacts.joinpath("CONFIGS_DUMP.txt").unlink()
-    artifacts.rmdir()
+    new_result = subprocess.run(new_command.split(), **launch_parameters)
     assert 'Hello world' in str(new_result.stdout)

--- a/tests/test_create_config.py
+++ b/tests/test_create_config.py
@@ -5,11 +5,11 @@ from .utils import python
 
 
 def test_create_config(tmpdir):
-    launch_parameters = dict(capture_output=True, check=True, cwd=tmpdir, env=dict(os.environ, PYTHONPATH=os.getcwd()))
-    result = subprocess.run([python(), "-m", "universum", "init"], **launch_parameters)
+    launch_parameters = dict(capture_output=True, cwd=tmpdir, env=dict(os.environ, PYTHONPATH=os.getcwd()))
+    result = subprocess.run([python(), "-m", "universum", "init"], check=True, **launch_parameters)
     new_command = ''
     for line in result.stdout.splitlines():
         if line.startswith(b'$ '):           # result.stdout is a byte string
             new_command = line.lstrip(b'$ ')
-    new_result = subprocess.run(new_command.split(), **launch_parameters)
+    new_result = subprocess.run(new_command.split(), check=True, **launch_parameters)
     assert 'Hello world' in str(new_result.stdout)


### PR DESCRIPTION
The reason why `.universum.py` unexpectedly disappeared.