### PR TITLE
fix(docker): bring back noninteractive environment

### DIFF
--- a/tests/docker/universum_test_env/Dockerfile
+++ b/tests/docker/universum_test_env/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y wget software-properties-common
 
 # Install latest python & pip
 RUN add-apt-repository ppa:deadsnakes/ppa && apt-get update
-RUN apt-get install -y ${PYTHON}-dev ${PYTHON}-distutils gnupg2 libssl-dev build-essential
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y ${PYTHON}-dev ${PYTHON}-distutils gnupg2 libssl-dev build-essential
 
 # Please note: wget is writing logs to stderr, these logs are not any kind of warning
 RUN wget --no-verbose --no-check-certificate -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'


### PR DESCRIPTION
It actually is required only by Python3.9 installation, but nevertheless