### PR TITLE
fix(p4): print warning instead of block failing

### DIFF
--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -493,7 +493,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
                     raise
                 self.out.log(f"Getting file diff via 'p4 opened' failed after {timeout} seconds timeout")
         else:
-            self.structure.fail_current_block()
+            self.out.log_stderr("Calculating file diff failed, leaving blank")
             return None
 
         for entry in opened_files:


### PR DESCRIPTION
User request due to TeamCity failing build if any blocks fail