### PR TITLE
feat(output): add sections collapsing in HTML output

### DIFF
--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -5,6 +5,7 @@ import pytest
 
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.firefox.webelement import FirefoxWebElement
 
 
 config = """
@@ -55,10 +56,101 @@ def check_html_log(artifact_dir, browser):
     assert os.path.exists(log_path)
 
     browser.get(f"file://{log_path}")
-    body_element = browser.find_element_by_tag_name("body")
-    body_elements = body_element.find_elements_by_xpath(".//*")
+    html_body = browser.find_element_by_tag_name("body")
+    body_elements = html_body.find_elements_by_xpath("./*")
     assert len(body_elements) == 1
+    assert body_elements[0].tag_name == "pre"
 
-    pre_element = body_elements[0]
-    assert pre_element.tag_name == "pre"
-    assert pre_element.text # will be changed to valid HTML in further commits
+    pre_element = TestElement.create(body_elements[0])
+    steps_section = pre_element.get_section_by_name("Executing build steps")
+    steps_body = steps_section.get_section_body()
+
+    check_step_collapsed(steps_section, steps_body)
+    steps_section.click()
+    check_step_not_collapsed(steps_section, steps_body)
+    check_sections_indentation(steps_section)
+    steps_section.click()
+    check_step_collapsed(steps_section, steps_body)
+
+
+def check_sections_indentation(steps_section):
+    steps_body = steps_section.get_section_body()
+    step_lvl1_first = steps_body.get_section_by_name("Failed step")
+    step_lvl1_second = steps_body.get_section_by_name("Partially success step")
+    assert step_lvl1_first.indent == step_lvl1_second.indent
+
+    step_lvl1_second.click()
+    step_lvl1_body = step_lvl1_second.get_section_body()
+    step_lvl2_first = step_lvl1_body.get_section_by_name("Success step")
+    step_lvl2_second = step_lvl1_body.get_section_by_name("Failed step")
+    assert step_lvl2_first.indent == step_lvl2_second.indent
+
+    assert steps_section.indent < step_lvl1_first.indent < step_lvl2_first.indent
+
+
+def check_step_collapsed(section, body):
+    assert section.is_section_collapsed
+    assert body.is_body_collapsed
+    assert not body.is_displayed()
+
+
+def check_step_not_collapsed(section, body):
+    assert not section.is_section_collapsed
+    assert not body.is_body_collapsed
+    assert body.is_displayed()
+
+
+class TestElement(FirefoxWebElement):
+
+    @staticmethod
+    def create(element):
+        assert(element)
+        element.__class__ = TestElement
+        return element;
+
+    # <input type="checkbox" id="1." class="hide">
+    # <label for="1.">  <-- returning this element
+    #     <span class="sectionLbl">1. Section name</span>  <-- Searching for this element
+    # </label>
+    # <div>Section body</div>
+    def get_section_by_name(self, section_name):
+        span_elements = self.find_elements_by_class_name("sectionLbl")
+        result = None
+        for el in span_elements:
+            if section_name in el.text:
+                result = el.find_element_by_xpath("..")
+        return TestElement.create(result)
+
+    def get_section_body(self):
+        body = TestElement.create(self.find_element_by_xpath("./following-sibling::*[1]"))
+        assert (body.tag_name == "div")
+        return body
+
+    @property
+    def is_body_collapsed(self):
+        display_state = self.value_of_css_property("display")
+        collapsed_state = "none"
+        not_collapsed_state = "block"
+        if display_state not in (collapsed_state, not_collapsed_state):
+            raise RuntimeError(f"Unexpected element display state: '{display_state}'")
+
+        collapsed = (display_state == collapsed_state)
+        collapsed &= (not self.text)
+        return collapsed
+
+    @property
+    def is_section_collapsed(self):
+        label_span = self.find_element_by_tag_name("span")
+        assert(label_span)
+        script = "return window.getComputedStyle(arguments[0],':before').getPropertyValue('content')"
+        section_state = self.parent.execute_script(script, label_span).replace('"', "").replace(" ", "");
+        collapsed_state = "[+]"
+        not_collapsed_state = "[-]"
+        if section_state not in (collapsed_state, not_collapsed_state):
+            raise RuntimeError(f"Unexpected section collapsed state: '{section_state}'")
+
+        return (section_state == collapsed_state)
+
+    @property
+    def indent(self):
+        return self.location['x']

--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -104,9 +104,9 @@ class TestElement(FirefoxWebElement):
 
     @staticmethod
     def create(element):
-        assert(element)
+        assert element
         element.__class__ = TestElement
-        return element;
+        return element
 
     # <input type="checkbox" id="1." class="hide">
     # <label for="1.">  <-- returning this element
@@ -123,7 +123,7 @@ class TestElement(FirefoxWebElement):
 
     def get_section_body(self):
         body = TestElement.create(self.find_element_by_xpath("./following-sibling::*[1]"))
-        assert (body.tag_name == "div")
+        assert body.tag_name == "div"
         return body
 
     @property
@@ -141,15 +141,15 @@ class TestElement(FirefoxWebElement):
     @property
     def is_section_collapsed(self):
         label_span = self.find_element_by_tag_name("span")
-        assert(label_span)
+        assert label_span
         script = "return window.getComputedStyle(arguments[0],':before').getPropertyValue('content')"
-        section_state = self.parent.execute_script(script, label_span).replace('"', "").replace(" ", "");
+        section_state = self.parent.execute_script(script, label_span).replace('"', "").replace(" ", "")
         collapsed_state = "[+]"
         not_collapsed_state = "[-]"
         if section_state not in (collapsed_state, not_collapsed_state):
             raise RuntimeError(f"Unexpected section collapsed state: '{section_state}'")
 
-        return (section_state == collapsed_state)
+        return section_state == collapsed_state
 
     @property
     def indent(self):

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -73,7 +73,8 @@ class HtmlOutput(BaseOutput):
         self._log_line(html_footer)
 
     def _log_line(self, line, with_line_separator=True):
-        line = f"{line}{os.linesep}" if with_line_separator else line
+        if with_line_separator and not line.endswith(os.linesep):
+            line += os.linesep
         if not self._filename:
             raise RuntimeError("Artifact directory was not set")
         if not self.artifact_dir_ready:

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -14,7 +14,7 @@ class HtmlOutput(BaseOutput):
         super().__init__(*args, **kwargs)
         self._filename = None
         self.artifact_dir_ready = False
-        self._log_buffer = list()
+        self._log_buffer = []
         self._block_level = 0
 
     def set_artifact_dir(self, artifact_dir):
@@ -86,21 +86,22 @@ class HtmlOutput(BaseOutput):
     def _log_and_clear_buffer(self):
         for buffered_line in self._log_buffer:
             self._write_to_file(buffered_line)
-        self._log_buffer = list()
+        self._log_buffer = []
 
     def _write_to_file(self, line):
-        with open(self._filename, "a") as file:
+        with open(self._filename, "a", encoding="utf-8") as file:
             file.write(self._build_indent())
             file.write(line)
 
     def _build_indent(self):
-        indent_str = list()
+        indent_str = []
         for x in range(0, self._block_level):
             indent_str.append("  " * x)
             indent_str.append(" |   ")
         return "".join(indent_str)
 
-    def _build_html_head(self):
+    @staticmethod
+    def _build_html_head():
         css_rules = '''
             .sectionLbl {
                 color: black;
@@ -138,7 +139,7 @@ class HtmlOutput(BaseOutput):
                 content: "[-] ";
             }
         '''
-        head = list()
+        head = []
         head.append('<meta content="text/html;charset=utf-8" http-equiv="Content-Type">')
         head.append('<meta content="utf-8" http-equiv="encoding">')
         head.append(f"<style>{css_rules}</style>")

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -21,13 +21,17 @@ class HtmlOutput(BaseOutput):
         self._filename = os.path.join(artifact_dir, "log.html")
 
     def open_block(self, num_str, name):
-        self._log_line(f"{num_str} {name}")
+        opening_html = f'<input type="checkbox" id="{num_str}" class="hide"/>' + \
+            f'<label for="{num_str}"><span class="sectionLbl">'
+        closing_html = "</span></label><div>"
+        self._log_line(f"{opening_html}{num_str} {name}{closing_html}", with_line_separator=False)
         self._block_level += 1
 
     def close_block(self, num_str, name, status):
         self._block_level -= 1
         indent = "  " * self._block_level
-        self._log_line(f"{indent} \u2514 [{status}]")
+        closing_html = '</div><span class="nl"></span>'
+        self._log_line(f"{indent} \u2514 [{status}]{closing_html}", with_line_separator=False)
         self._log_line("")
 
     def report_error(self, description):
@@ -58,7 +62,8 @@ class HtmlOutput(BaseOutput):
         self._log_line(line)
 
     def log_execution_start(self, title, version):
-        html_header = "<!DOCTYPE html><html><head></head><body><pre>"
+        head_content = self._build_html_head()
+        html_header = f"<!DOCTYPE html><html><head>{head_content}</head><body><pre>"
         self._log_line(html_header)
         self.log(self._build_execution_start_msg(title, version))
 
@@ -67,7 +72,8 @@ class HtmlOutput(BaseOutput):
         html_footer = "</pre></body></html>"
         self._log_line(html_footer)
 
-    def _log_line(self, line):
+    def _log_line(self, line, with_line_separator=True):
+        line = f"{line}{os.linesep}" if with_line_separator else line
         if not self._filename:
             raise RuntimeError("Artifact directory was not set")
         if not self.artifact_dir_ready:
@@ -86,7 +92,6 @@ class HtmlOutput(BaseOutput):
         with open(self._filename, "a") as file:
             file.write(self._build_indent())
             file.write(line)
-            file.write(os.linesep)
 
     def _build_indent(self):
         indent_str = list()
@@ -94,3 +99,47 @@ class HtmlOutput(BaseOutput):
             indent_str.append("  " * x)
             indent_str.append(" |   ")
         return "".join(indent_str)
+
+    def _build_html_head(self):
+        css_rules = '''
+            .sectionLbl {
+                color: black;
+            }
+            .sectionLbl span {
+                color: black !important;
+            }
+
+            .hide {
+                display: none;
+            }
+            .hide + label ~ div {
+                display: none;
+            }
+            .hide + label {
+                color: black;
+                cursor: pointer;
+                display: inline-block;
+            }
+            .hide:checked + label + div {
+                display: block;
+            }
+
+            .hide + label + div + .nl {
+                display: block;
+            }
+            .hide:checked + label + div + .nl::after {
+                display: none;
+            }
+
+            .hide + label .sectionLbl::before {
+                content: "[+] ";
+            }
+            .hide:checked + label .sectionLbl::before {
+                content: "[-] ";
+            }
+        '''
+        head = list()
+        head.append('<meta content="text/html;charset=utf-8" http-equiv="Content-Type">')
+        head.append('<meta content="utf-8" http-equiv="encoding">')
+        head.append(f"<style>{css_rules}</style>")
+        return "".join(head)


### PR DESCRIPTION
Wrapping HTML example:
```
<input type="checkbox" id="1." class="hide">
<label for="1.">
<span class="sectionLbl">1. Section name</span>
</label>
<div>Section body</div>
```

Expected behavior:
* all steps are collapsed at HTML opening
* click on collapsed section name leads to:
    - section body is shown, inner sections are collapsed
    - section marker changed from `[+]` to `[-]`
* click on not collapsed section name leads to opposite change