### PR TITLE
refactor(pylint): updated according to new recommendations

### DIFF
--- a/doc/configuring.rst
+++ b/doc/configuring.rst
@@ -6,6 +6,11 @@ Project configuration
 In order to use the `Universum`, the project should provide a configuration file.
 This file is a regular python script with specific interface, which is recognized by the `Universum`.
 
+.. note::
+
+    This file is expected to be in UTF-8 (Unicode) encoding. Please note, that any encoding specifications,
+    such as BOM and PEP263 headers, will be ignored.
+
 By default, configuration file is called ``.universum.py`` and is located in the project root directory.
 To create one automatically, execute ``{python} -m universum init`` in the project root directory. To use another
 file name or file path, use ``--config`` / ``-cfg`` `command-line parameter <args.html#Configuration\ execution>`__

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import universum
 
 
 def readme():
-    with open('README.md') as f:
+    with open('README.md', encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -222,7 +222,7 @@ class UniversumRunner:
 
     def _create_temp_config(self, config: str):
         file_path = os.path.join(self.working_dir, "temp_config.py")
-        with open(file_path, 'w+') as f:
+        with open(file_path, 'w+', encoding="utf-8") as f:
             f.write(config)
         return file_path
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,7 +34,7 @@ def test_p4_file_diff(docker_main_with_vcs):
                                    additional_parameters=" --p4-force-clean")
     assert "Module sh got exit code" not in log
 
-    with open(path.join(docker_main_with_vcs.artifact_dir, "output.json")) as f:
+    with open(path.join(docker_main_with_vcs.artifact_dir, "output.json"), encoding="utf-8") as f:
         result = json.load(f)
 
     assert result[0]["action"] == "move/add"
@@ -60,7 +60,7 @@ def test_multiple_p4_file_diff(docker_main_with_vcs):
                                    additional_parameters=" --p4-force-clean")
     assert "Module sh got exit code" not in log
 
-    with open(path.join(docker_main_with_vcs.artifact_dir, "output.json")) as f:
+    with open(path.join(docker_main_with_vcs.artifact_dir, "output.json"), encoding="utf-8") as f:
         result = json.load(f)
     assert len(result) == 10000
     for entry in result:
@@ -85,7 +85,7 @@ def test_git_file_diff(docker_main_with_vcs):
                                                 f"GIT_REFSPEC={server.target_branch}"])
     assert "Module sh got exit code" not in log
 
-    with open(path.join(docker_main_with_vcs.artifact_dir, "output.json")) as f:
+    with open(path.join(docker_main_with_vcs.artifact_dir, "output.json"), encoding="utf-8") as f:
         result = json.load(f)
 
     assert result[0]["action"] == "rename"
@@ -115,7 +115,7 @@ def test_multiple_git_file_diff(docker_main_with_vcs):
                                                 f"GIT_REFSPEC={server.target_branch}"])
     assert "Module sh got exit code" not in log
 
-    with open(path.join(docker_main_with_vcs.artifact_dir, "output.json")) as f:
+    with open(path.join(docker_main_with_vcs.artifact_dir, "output.json"), encoding="utf-8") as f:
         result = json.load(f)
     assert len(result) == 10000
     for entry in result:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -208,18 +208,18 @@ configs = Configuration([Step(name="Step one"),
 
 def test_minimal_git(docker_main_with_vcs):
     log = docker_main_with_vcs.run("""
-from universum.configuration_support import Configuration
+from universum.configuration_support import Configuration, Step
 
-configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([Step(name="Test step", command=["ls", "-la"])])
 """, vcs_type="git")
     assert docker_main_with_vcs.git.repo_file.basename in log
 
 
 def test_minimal_p4(docker_main_with_vcs):
     log = docker_main_with_vcs.run("""
-from universum.configuration_support import Configuration
+from universum.configuration_support import Configuration, Step
 
-configs = Configuration([dict(name="Test configuration", command=["ls", "-la"])])
+configs = Configuration([Step(name="Test step", command=["ls", "-la"])])
 """, vcs_type="p4")
     assert docker_main_with_vcs.perforce.repo_file.basename in log
 
@@ -228,9 +228,9 @@ def test_p4_params(docker_main_with_vcs):
     p4 = docker_main_with_vcs.perforce.p4
     p4_file = docker_main_with_vcs.perforce.repo_file
     config = """
-from universum.configuration_support import Configuration
+from universum.configuration_support import Configuration, Step
 
-configs = Configuration([dict(name="Test configuration", command=["cat", "{}"])])
+configs = Configuration([step(name="Test step", command=["cat", "{}"])])
 """.format(p4_file.basename)
 
     # Prepare SYNC_CHANGELIST

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -230,7 +230,7 @@ def test_p4_params(docker_main_with_vcs):
     config = """
 from universum.configuration_support import Configuration, Step
 
-configs = Configuration([step(name="Test step", command=["cat", "{}"])])
+configs = Configuration([Step(name="Test step", command=["cat", "{}"])])
 """.format(p4_file.basename)
 
     # Prepare SYNC_CHANGELIST

--- a/tests/test_p4_submit.py
+++ b/tests/test_p4_submit.py
@@ -14,7 +14,7 @@ def test_fail_changing_non_checked_out_file(p4_submit_environment):
     target_file = p4_submit_environment.nonwritable_file
     text = utils.randomize_name("This is change ")
     with pytest.raises(IOError) as excinfo:
-        with open(str(target_file), "w") as tmpfile:
+        with open(str(target_file), "w", encoding="utf-8") as tmpfile:
             tmpfile.write(text + "\n")
 
     assert "Permission denied" in str(excinfo.value)

--- a/universum/analyzers/sarif_report.py
+++ b/universum/analyzers/sarif_report.py
@@ -21,7 +21,7 @@ def main(settings: argparse.Namespace) -> List[utils.ReportData]:
 def sarif_report_output_parser(file_list: List[str]) -> List[utils.ReportData]:
     result: List[utils.ReportData] = []
     for report_file in file_list:
-        with open(report_file, "r") as f:
+        with open(report_file, "r", encoding="utf-8") as f:
             report = json.loads(f.read())
             try:
                 result.extend(parse_sarif_json(report))

--- a/universum/analyzers/scan_build_report.py
+++ b/universum/analyzers/scan_build_report.py
@@ -20,7 +20,7 @@ def main(settings: argparse.Namespace) -> List[utils.ReportData]:
 def scan_build_report_output_parser(file_list: List[str]) -> List[utils.ReportData]:
     result: List[utils.ReportData] = []
     for report_file in file_list:
-        with open(report_file) as f:
+        with open(report_file, encoding="utf-8") as f:
             parser = etree.HTMLParser()
             tree: etree.ElementTree = etree.parse(f, parser)
             found = any(x.text for x in tree.iter() if x.text == 'Bug Summary')

--- a/universum/analyzers/uncrustify.py
+++ b/universum/analyzers/uncrustify.py
@@ -60,7 +60,7 @@ class HtmlDiffFileWriter:
     def __call__(self, file: Path, src: List[str], target: List[str]) -> None:
         file_relative = file.relative_to(Path.cwd())
         out_file_name: str = str(file_relative).replace('/', '_') + '.html'
-        with open(self.target_folder.joinpath(out_file_name), 'w') as out_file:
+        with open(self.target_folder.joinpath(out_file_name), 'w', encoding="utf-8") as out_file:
             out_file.write(self.differ.make_file(src, target, context=False))
 
 
@@ -69,9 +69,9 @@ def uncrustify_output_parser(files: List[Tuple[Path, Path]],
                              ) -> List[utils.ReportData]:
     result: List[utils.ReportData] = []
     for src_file, uncrustify_file in files:
-        with open(src_file) as src:
+        with open(src_file, encoding="utf-8") as src:
             src_lines = src.readlines()
-        with open(uncrustify_file) as fixed:
+        with open(uncrustify_file, encoding="utf-8") as fixed:
             fixed_lines = fixed.readlines()
 
         issues = _get_issues_from_diff(src_file, src_lines, fixed_lines)
@@ -82,7 +82,7 @@ def uncrustify_output_parser(files: List[Tuple[Path, Path]],
 
 
 def _get_wrapcolumn_tabsize(cfg_file: str) -> Tuple[int, int]:
-    with open(cfg_file) as config:
+    with open(cfg_file, encoding="utf-8") as config:
         for line in config.readlines():
             if line.startswith("code_width"):
                 wrapcolumn = int(line.split()[2])
@@ -150,7 +150,7 @@ def _get_text_for_block(start: int, end: int, lines: List[str]) -> str:
 
 
 def _replace_invisible_symbols(line: str) -> str:
-    for old_str, new_str in zip([u" ", u"\t", u"\n"], [u"\u00b7", u"\u2192\u2192\u2192\u2192", u"\u2193\u000a"]):
+    for old_str, new_str in zip([" ", "\t", "\n"], ["\u00b7", "\u2192\u2192\u2192\u2192", "\u2193\u000a"]):
         line = line.replace(old_str, new_str)
     return line
 

--- a/universum/analyzers/utils.py
+++ b/universum/analyzers/utils.py
@@ -132,7 +132,7 @@ def add_python_version_argument(parser: argparse.ArgumentParser) -> None:
 def report_to_file(issues: List[ReportData], json_file: str = None) -> None:
     issues_json = json.dumps(issues, indent=4)
     if json_file:
-        with open(json_file, "w") as f:
+        with open(json_file, "w", encoding="utf-8") as f:
             f.write(issues_json)
     else:
         sys.stdout.write(issues_json)

--- a/universum/github_handler.py
+++ b/universum/github_handler.py
@@ -18,7 +18,9 @@ class GithubHandler(GithubToken, HasOutput, HasStructure, HasErrorState):
                                      help='Currently parsed from "x-github-event" header of received web-hook')
         argument_parser.add_argument('--payload', '-pl', dest='payload', metavar="GITHUB_PAYLOAD",
                                      help='Full contents of web-hook received; pass a JSON file path, starting it '
-                                          'with "@" character, or use an environment variable for convenience')
+                                          'with "@" character, or use an environment variable for convenience. '
+                                          'Please note, that when passing a file, it is expected to be '
+                                          'in UTF-8 encoding')
         argument_parser.add_argument('--trigger-url', '-tu', dest='trigger_url', metavar="TRIGGER_URL",
                                      help='URL for GET request to trigger the CI build and pass all parameters '
                                           'parsed from payload; if any constant parameters (like token) are '
@@ -57,7 +59,8 @@ class GithubHandler(GithubToken, HasOutput, HasStructure, HasErrorState):
             '--payload' ('-pl') command line parameter or by setting GITHUB_PAYLOAD
             environment variable, or by passing file path as the argument value (start
             filename with '@' character, e.g. '@/tmp/file.json' or '@payload.json' for
-            relative path starting at current directory)
+            relative path starting at current directory). Please note, that when passing
+            a file, it's expected to be in UTF-8 encoding
             """)
 
     @make_block("Analysing trigger payload")

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -75,7 +75,7 @@ ComponentType = TypeVar('ComponentType', bound=Module)
 
 def construct_component(cls: Type[ComponentType], main_settings: 'HasModulesMapping', *args, **kwargs) -> ComponentType:
     if not getattr(main_settings, "active_modules", None):
-        main_settings.active_modules = dict()
+        main_settings.active_modules = {}
 
     if cls not in main_settings.active_modules:
         cls.settings = Settings(cls)
@@ -107,7 +107,7 @@ class Dependency(Generic[DependencyType]):
 
 def get_dependencies(cls: Type[Module], result: Optional[List[Type[Module]]] = None) -> List[Type[Module]]:
     if result is None:
-        result = list()
+        result = []
 
     result.append(cls)
 

--- a/universum/lib/module_arguments.py
+++ b/universum/lib/module_arguments.py
@@ -71,7 +71,7 @@ class ModuleArgumentGroup(argparse._ArgumentGroup):
 class ModuleArgumentParser(argparse.ArgumentParser):
 
     def __init__(self, **kwargs):
-        self.groups = dict()
+        self.groups = {}
         self.dest_prefix = ''
         argparse.ArgumentParser.__init__(self, **kwargs)
 

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -48,7 +48,7 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
     def report_code_report_results(self) -> None:
         reports: List[str] = glob.glob(self.report_path + "/*.json")
         for report_file in reports:
-            with open(report_file, "r") as f:
+            with open(report_file, "r", encoding="utf-8") as f:
                 text: str = f.read()
                 report: Optional[List[Dict[str, str]]] = None
                 if text:

--- a/universum/modules/error_state.py
+++ b/universum/modules/error_state.py
@@ -41,7 +41,7 @@ class HasErrorState(Module):
             return ""
         if value.startswith('@'):
             try:
-                with open(value.lstrip('@')) as value_file:
+                with open(value.lstrip('@'), encoding="utf-8") as value_file:
                     return value_file.read()
             except FileNotFoundError as e:
                 self.error(f"Error reading argument {setting_name} from file {e.filename}: no such file")

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -223,7 +223,7 @@ class RunningStep:
         if self.file:
             self.file.write("$ " + log_cmd + "\n")
 
-    def handle_stdout(self, line: str = u"") -> None:
+    def handle_stdout(self, line: str = "") -> None:
         line = utils.trim_and_convert_to_unicode(line)
 
         if self.file:
@@ -358,7 +358,7 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
         sys.path.append(os.path.join(os.path.dirname(config_path)))
 
         try:
-            with open(config_path) as config_file:
+            with open(config_path, encoding="utf-8") as config_file:
                 exec(config_file.read(), config_globals)  # pylint: disable=exec-used
             self.source_project_configs = config_globals["configs"]
             dump_file: TextIO = self.artifacts.create_text_file("CONFIGS_DUMP.txt")

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -14,7 +14,7 @@ class HtmlOutput(BaseOutput):
         super().__init__(*args, **kwargs)
         self._filename = None
         self.artifact_dir_ready = False
-        self._log_buffer = list()
+        self._log_buffer = []
         self._block_level = 0
 
     def set_artifact_dir(self, artifact_dir):
@@ -80,16 +80,16 @@ class HtmlOutput(BaseOutput):
     def _log_and_clear_buffer(self):
         for buffered_line in self._log_buffer:
             self._write_to_file(buffered_line)
-        self._log_buffer = list()
+        self._log_buffer = []
 
     def _write_to_file(self, line):
-        with open(self._filename, "a") as file:
+        with open(self._filename, "a", encoding="utf-8") as file:
             file.write(self._build_indent())
             file.write(line)
             file.write(os.linesep)
 
     def _build_indent(self):
-        indent_str = list()
+        indent_str = []
         for x in range(0, self._block_level):
             indent_str.append("  " * x)
             indent_str.append(" |   ")

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -11,37 +11,37 @@ def escape(message):
 
 class TeamcityOutput(BaseOutput):
     def open_block(self, num_str, name):
-        print(u"##teamcity[blockOpened name='{} {}']".format(num_str, escape(name)))
+        print("##teamcity[blockOpened name='{} {}']".format(num_str, escape(name)))
 
     def close_block(self, num_str, name, status):
-        print(u"##teamcity[blockClosed name='{} {}']".format(num_str, escape(name)))
+        print("##teamcity[blockClosed name='{} {}']".format(num_str, escape(name)))
 
     def report_error(self, description):
-        print(u"##teamcity[buildProblem description='<{}>']".format(escape(description)))
+        print("##teamcity[buildProblem description='<{}>']".format(escape(description)))
 
     def report_skipped(self, message):
         lines = message.split("\n")
         for single_line in lines:
-            print(u"##teamcity[message text='{}' status='WARNING']".format(escape(single_line)))
+            print("##teamcity[message text='{}' status='WARNING']".format(escape(single_line)))
 
     def change_status(self, message):
-        print(u"##teamcity[buildStatus text='{}']".format(escape(message)))
+        print("##teamcity[buildStatus text='{}']".format(escape(message)))
 
     def log_exception(self, line):
         lines = line.split("\n")
         for single_line in lines:
-            print(u"##teamcity[message text='{}' status='ERROR']".format(escape(single_line)))
+            print("##teamcity[message text='{}' status='ERROR']".format(escape(single_line)))
 
     def log_stderr(self, line):
         lines = line.split("\n")
         for single_line in lines:
-            print(u"##teamcity[message text='{}' status='WARNING']".format(escape(single_line)))
+            print("##teamcity[message text='{}' status='WARNING']".format(escape(single_line)))
 
     def log(self, line):
-        print(u"==>", line)
+        print("==>", line)
 
     def log_external_command(self, command):
-        print(u"$", command)
+        print("$", command)
 
     def log_shell_output(self, line):
         print(line)

--- a/universum/modules/vcs/base_vcs.py
+++ b/universum/modules/vcs/base_vcs.py
@@ -19,7 +19,7 @@ class BaseVcs(ProjectDirectory):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.repo_status = u""
+        self.repo_status = ""
         self.sources_need_cleaning = False
 
     def append_repo_status(self, line):

--- a/universum/modules/vcs/github_vcs.py
+++ b/universum/modules/vcs/github_vcs.py
@@ -33,7 +33,8 @@ class GithubToken(HasErrorState):
         parser.add_argument("--github-private-key", "-gtk", dest="key", metavar="GITHUB_PRIVATE_KEY",
                             help="GitHub App private key for obtaining installation authentication token. "
                                  "Pass raw key data via environment variable or pass a file path to read the key from "
-                                 "by starting the value string with '@'. File path can be either absolute or relative")
+                                 "by starting the value string with '@'. File path can be either absolute or relative. "
+                                 "Please note, that when passing a file, it is expected to be in UTF-8 encoding")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -65,6 +66,7 @@ class GithubToken(HasErrorState):
             directly via command line. If you start the parameter with '@', the rest should be
             the path to a file containing the key. The path can be absolute or relative to the 
             project root. You can also store the key in GITHUB_PRIVATE_KEY environment variable.
+            Please note, that when passing a file, it's expected to be in UTF-8 encoding")
             """)
 
         global github

--- a/universum/modules/vcs/github_vcs.py
+++ b/universum/modules/vcs/github_vcs.py
@@ -171,7 +171,7 @@ class GithubMainVcs(ReportObserver, git_vcs.GitMainVcs, GithubTokenWithInstallat
             from the webhook payload and passed via GITHUB_CHECK_ID environment variable.
             """)
 
-        self.request = dict()
+        self.request = {}
         self.request["status"] = "in_progress"
         self.request["output"] = {
             "title": self.settings.check_name,

--- a/universum/poll.py
+++ b/universum/poll.py
@@ -53,7 +53,7 @@ class Poll(HasOutput, HasStructure):
     @make_block("Enumerating changes")
     def execute(self):
         try:
-            with open(self.settings.db_file) as db_file:
+            with open(self.settings.db_file, encoding="utf-8") as db_file:
                 self.stored_cls = json.load(db_file)
         except IOError as io_error:
             if io_error.errno == 2:
@@ -68,7 +68,7 @@ class Poll(HasOutput, HasStructure):
         except NotImplementedError:
             self.out.log("Polling is skipped because current VCS doesn't support it")
         finally:
-            with open(self.settings.db_file, "w") as db_file:
+            with open(self.settings.db_file, "w", encoding="utf-8") as db_file:
                 json.dump(self.stored_cls, db_file, indent=4, sort_keys=True)
 
     def finalize(self):

--- a/universum/submit.py
+++ b/universum/submit.py
@@ -24,13 +24,16 @@ class Submit(HasOutput, HasStructure, HasErrorState):
         parser.add_argument('--commit-message', '-cm', dest='commit_message', metavar="COMMIT_MESSAGE",
                             help="Commit message. Enter in command line directly, store in environment variable "
                                  "or pass a file path to read the message from by starting the value string with "
-                                 "'@'. File path can be either absolute or relative")
+                                 "'@'. File path can be either absolute or relative. "
+                                 "Please note, that when passing a file, it is expected to be in UTF-8 encoding")
         parser.add_argument("--reconcile-list", "-rl", dest="reconcile_list", metavar="RECONCILE_LIST",
                             help="Comma-separated or linebreak-separated list of files or directories "
                                  "to be reconciled for commit (relative paths starting at client root "
                                  "are supported). To use command line directly, add quotes if needed "
                                  "(e.g. ``-rl 'target1, target2'``). To use a file with reconcile list, "
-                                 "start a path to file with '@' (e.g. ``-rl @/path/to/file``)")
+                                 "start a path to file with '@' (e.g. ``-rl @/path/to/file``)."
+                                 "Please note, that when passing a file, it's expected to be in UTF-8 "
+                                 "encoding")
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -40,6 +43,7 @@ class Submit(HasOutput, HasStructure, HasErrorState):
             Please use '--commit-message' option to provide it. If you start the parameter with '@', the
             rest should be the path to a file containing the commit message text. The path can be absolute
             or relative to the project root. You can also store the message in COMMIT_MESSAGE environment variable.
+            Please note, that when passing a file, it's expected to be in UTF-8 encoding
             """)
 
         try:


### PR DESCRIPTION
1. open() is recommended to use with specific encoding
   instead of relying on autodetect
2. list and dict literals are recommended for use instead of
   constructors for optimization reasons
3. 'u""' prefix is no longer required, as strings are unicode
   by default