### PR TITLE
fix(setup): freeze selenium on before FirefoxWebElement was removed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
             'coverage',
             'mypy',
             'types-requests',
-            'selenium'
+            'selenium==3.141'
         ]
     }
 )


### PR DESCRIPTION
In the 4.0 version of selenium-python there's no such class left anywhere (though basic WebElement is still there).