### PR TITLE
test(output): more flexible section status element search 

### DIFF
--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -225,7 +225,7 @@ class TestElement(FirefoxWebElement):
     # </div>
     def get_section_status(self):
         body = self.get_section_body()
-        xpath_selector = "./*[contains(text(), 'Success') or contains(text(), 'Failed')]"
+        xpath_selector = "./*[contains(text(), '[Success]') or contains(text(), '[Failed]')]"
         return TestElement.create(body.find_elements_by_xpath(xpath_selector)[-1])
 
     @property


### PR DESCRIPTION
**Before:**
Search for the last `<span>` element in a section body. Then check that text is "Success"/"Failed".
**Now:**
Search for the last element in a section body with any tag and "Success"/"Failed" text inside.
The dependency on the element tag no more exists.