### PR TITLE
fix(setup): remove sphinx version pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ github = (git, 'cryptography', 'pygithub')
 
 vcs = p4 + github
 
-docs = ('sphinx==3.4.3', 'sphinx-argparse', 'sphinx_rtd_theme')  # This extra is required for RTD to generate documentation
+docs = ('sphinx', 'sphinx-argparse', 'sphinx_rtd_theme')  # This extra is required for RTD to generate documentation
 
 setup(
     name=universum.__title__,


### PR DESCRIPTION
I guess, pinning the exact versions of some modules (including, but not necessarily limited to `sphinx-rtd-theme`) should work too; but I'd rather pin them all at the same time in scope of corresponding task (#280, likely)