### PR TITLE
feat(output): dark mode switch in HTML log

### DIFF
--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -79,9 +79,8 @@ def check_html_log(artifact_dir, browser):
 
     browser.get(f"file://{log_path}")
     html_body = TestElement.create(browser.find_element_by_tag_name("body"))
-    body_elements = html_body.find_elements_by_xpath("./*")
+    body_elements = html_body.find_elements_by_xpath("./pre")
     assert len(body_elements) == 1
-    assert body_elements[0].tag_name == "pre"
 
     universum_log_element = TestElement.create(body_elements[0])
     steps_section = universum_log_element.get_section_by_name("Executing build steps")
@@ -94,6 +93,7 @@ def check_html_log(artifact_dir, browser):
     check_coloring(html_body, universum_log_element, steps_section)
     steps_section.click()
     assert not steps_body.is_displayed()
+    check_dark_mode(html_body, universum_log_element)
 
 
 def check_sections_indentation(steps_section):
@@ -192,6 +192,14 @@ def check_text_is_bold(element):
     assert element.font_weight == font_weight_bold
 
 
+def check_dark_mode(body_element, universum_log_element):
+    dark_mode_switch = TestElement.create(body_element.find_elements_by_xpath("./label")[0])
+    dark_mode_switch.click()
+    assert universum_log_element.color == Color.WHITE
+    assert universum_log_element.background_color == Color.BLACK
+    dark_mode_switch.click()
+    assert universum_log_element.color == Color.BLACK
+
 
 class TestElement(FirefoxWebElement):
 
@@ -279,7 +287,7 @@ class TestElement(FirefoxWebElement):
         color = None
         if lightness <= 20:
             color = Color.BLACK
-        elif lightness >= 90:
+        elif lightness >= 80:
             color = Color.WHITE
         elif 0 <= hue <= 30 or 330 <= hue <= 360:
             color = Color.RED

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -68,7 +68,8 @@ class HtmlOutput(BaseOutput):
 
     def log_execution_start(self, title, version):
         head_content = self._build_html_head()
-        html_header = f"<!DOCTYPE html><html><head>{head_content}</head><body><pre>"
+        html_header = f"<!DOCTYPE html><html><head>{head_content}</head><body>"
+        html_header += '<input type="checkbox" id="dark-checkbox"><label for="dark-checkbox"></label><pre>'
         self._log_line(html_header)
         self.log(self._build_execution_start_msg(title, version))
 
@@ -112,6 +113,10 @@ class HtmlOutput(BaseOutput):
             body {
                 background-color: white;
                 color: black;
+                margin: 0;
+                height: 100%;
+                min-height: 100vh;
+                display: flex;
             }
 
             .sectionTitle {
@@ -141,7 +146,7 @@ class HtmlOutput(BaseOutput):
                 display: none;
             }
             .hide + label {
-                color: black;
+
                 cursor: pointer;
                 display: inline-block;
             }
@@ -162,6 +167,74 @@ class HtmlOutput(BaseOutput):
             .hide:checked + label .sectionLbl::before {
                 content: "[-] ";
             }
+
+            #dark-checkbox {
+                display: none;
+            }
+    
+            pre {
+                padding: 20px 20px 65px 20px;
+                margin: 0;
+                width: 100%;
+            }
+    
+            #dark-checkbox:checked+label+pre {
+                background-color: black;
+                color: rgb(219, 198, 198);
+            }
+    
+            #dark-checkbox:checked+label+pre .sectionTitle {
+                color: #2b7cdf;
+            }
+            
+            #dark-checkbox+label {
+                position: fixed;
+                right: 15px;
+                bottom: 15px;
+                width: 95px;
+                height: 30px;
+                border-radius: 20px;
+                background-color: white;
+                color: gray;
+                border: gray 1px solid;
+                font: 12px sans;
+                cursor: pointer;
+            }
+    
+            #dark-checkbox:checked+label {
+                background-color: black;
+                color: white;
+            }
+    
+            #dark-checkbox+label::before {
+                position: absolute;
+                content: "";
+                height: 22px;
+                width: 22px;
+                left: 4px;
+                bottom: 4px;
+                background-color: gray;
+                transition: .3s;
+                border-radius: 50%;
+            }
+    
+            #dark-checkbox:checked+label::before {
+                background-color: white;
+                transform: translateX(65px);
+            }
+    
+            #dark-checkbox+label::after {
+                content: 'Light';
+                display: block;
+                position: absolute;
+                transform: translate(-50%, -50%);
+                top: 50%;
+                left: 50%;
+            }
+    
+            #dark-checkbox:checked+label::after {
+                content: 'Dark';
+            }    
         '''
         head = []
         head.append('<meta content="text/html;charset=utf-8" http-equiv="Content-Type">')


### PR DESCRIPTION
The switch looks like below:

![Screenshot from 2021-10-29 19-08-49](https://user-images.githubusercontent.com/46344924/139467865-6e20bd59-7f13-49af-9384-61f5a107c6bb.png)
![Screenshot from 2021-10-29 19-09-50](https://user-images.githubusercontent.com/46344924/139467869-6814420c-2ddc-4adf-95bb-ea727d27ba2e.png)

