### PR TITLE
feat(output): HTML log_exception() coloring

### DIFF
--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -90,7 +90,7 @@ def check_html_log(artifact_dir, browser):
     steps_section.click()
     assert steps_body.is_displayed()
     check_sections_indentation(steps_section)
-    check_coloring(html_body, universum_log_element, steps_section)
+    check_coloring(html_body, universum_log_element, steps_body)
     steps_section.click()
     assert not steps_body.is_displayed()
     check_dark_mode(html_body, universum_log_element)
@@ -112,11 +112,12 @@ def check_sections_indentation(steps_section):
     step_lvl1_second.click() # restore sections state
 
 
-def check_coloring(body_element, universum_log_element, steps_section):
+def check_coloring(body_element, universum_log_element, steps_body):
     check_body_coloring(body_element)
-    check_title_and_status_coloring(steps_section)
-    check_skipped_steps_coloring(steps_section)
+    check_title_and_status_coloring(steps_body)
+    check_skipped_steps_coloring(steps_body)
     check_steps_report_coloring(universum_log_element)
+    check_exception_tag_coloring(steps_body)
 
 
 def check_body_coloring(body_element):
@@ -124,9 +125,7 @@ def check_body_coloring(body_element):
     assert body_element.background_color == Color.WHITE
 
 
-def check_title_and_status_coloring(steps_section):
-    steps_body = steps_section.get_section_body()
-
+def check_title_and_status_coloring(steps_body):
     check_section_coloring(steps_body.get_section_by_name("Success step"))
     check_section_coloring(steps_body.get_section_by_name("Failed step"), is_failed=True)
     check_section_coloring(steps_body.get_section_by_name("Partially success step"))
@@ -141,8 +140,7 @@ def check_title_and_status_coloring(steps_section):
     composite_step.click()  # restore sections state
 
 
-def check_skipped_steps_coloring(steps_section):
-    steps_body = steps_section.get_section_body()
+def check_skipped_steps_coloring(steps_body):
     skipped_steps = steps_body.find_elements_by_class_name("skipped")
     assert skipped_steps
     skipped_steps = [TestElement.create(step) for step in skipped_steps]
@@ -167,6 +165,16 @@ def check_steps_report_coloring(universum_log_element):
             assert False, f"Unexpected element text: '{el.text}'"
 
     report_section.click() # restore section state
+
+
+def check_exception_tag_coloring(steps_body):
+    step = steps_body.get_section_by_name("Failed step")
+    step_body = step.get_section_body()
+    step.click()
+    xpath_selector = "./*[text() = 'Error:']"
+    exception_tag = TestElement.create(step_body.find_element_by_xpath(xpath_selector))
+    assert exception_tag.color == Color.RED
+    step.click()
 
 
 def check_section_coloring(step, is_failed=False):

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -52,7 +52,7 @@ class HtmlOutput(BaseOutput):
         pass
 
     def log_exception(self, line):
-        self._log_line(f"Error: {line}")
+        self._log_line(f'<span class="exceptionTag">Error:</span> {line}')
 
     def log_stderr(self, line):
         self._log_line(f"stderr: {line}")
@@ -138,6 +138,9 @@ class HtmlOutput(BaseOutput):
             .skipped {
                 color: darkcyan;
             }
+            .exceptionTag {
+                color: darkred;
+            }
 
             .hide {
                 display: none;
@@ -171,22 +174,22 @@ class HtmlOutput(BaseOutput):
             #dark-checkbox {
                 display: none;
             }
-    
+
             pre {
                 padding: 20px 20px 65px 20px;
                 margin: 0;
                 width: 100%;
             }
-    
+
             #dark-checkbox:checked+label+pre {
                 background-color: black;
                 color: rgb(219, 198, 198);
             }
-    
+
             #dark-checkbox:checked+label+pre .sectionTitle {
                 color: #2b7cdf;
             }
-            
+
             #dark-checkbox+label {
                 position: fixed;
                 right: 15px;
@@ -200,12 +203,12 @@ class HtmlOutput(BaseOutput):
                 font: 12px sans;
                 cursor: pointer;
             }
-    
+
             #dark-checkbox:checked+label {
                 background-color: black;
                 color: white;
             }
-    
+
             #dark-checkbox+label::before {
                 position: absolute;
                 content: "";
@@ -217,12 +220,12 @@ class HtmlOutput(BaseOutput):
                 transition: .3s;
                 border-radius: 50%;
             }
-    
+
             #dark-checkbox:checked+label::before {
                 background-color: white;
                 transform: translateX(65px);
             }
-    
+
             #dark-checkbox+label::after {
                 content: 'Light';
                 display: block;
@@ -231,10 +234,10 @@ class HtmlOutput(BaseOutput):
                 top: 50%;
                 left: 50%;
             }
-    
+
             #dark-checkbox:checked+label::after {
                 content: 'Dark';
-            }    
+            }
         '''
         head = []
         head.append('<meta content="text/html;charset=utf-8" http-equiv="Content-Type">')


### PR DESCRIPTION
Coloring "Error:" exceptions prefix in dark read, as it was done in `TerminalBasedOutput`.