### PR TITLE
feat(output): expand failed HTML sections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
             'types-requests',
             'selenium==3.141'
         ]
-    }
+    },
+    package_data={'': ['*.css', '*.js']}
 )
 
 

--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -193,10 +193,10 @@ def check_errors_tags_coloring(steps_body):
 
 def check_section_coloring(step, is_failed=False, has_inner_fail=False):
     is_section_failed = is_failed or has_inner_fail
-    check_text_item_style(step.get_section_title(), is_section_failed, normal_color=Color.BLUE);
+    check_text_item_style(step.get_section_title(), is_section_failed, normal_color=Color.BLUE)
     if not is_section_failed:
         step.click() # open section body
-    check_text_item_style(step.get_section_status(), is_failed, normal_color=Color.GREEN);
+    check_text_item_style(step.get_section_status(), is_failed, normal_color=Color.GREEN)
     if not is_section_failed:
         step.click() # close section body
 

--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -89,15 +89,39 @@ def check_html_log(artifact_dir, browser):
     steps_section = universum_log_element.get_section_by_name("Executing build steps")
     steps_body = steps_section.get_section_body()
 
-    assert not steps_body.is_displayed()
-    steps_section.click()
-    assert steps_body.is_displayed()
+    check_initial_sections_display_state(universum_log_element, steps_body)
+    check_manual_section_expanding(steps_body)
     check_sections_indentation(steps_section)
     check_coloring(html_body, universum_log_element, steps_body)
-    steps_section.click()
-    assert not steps_body.is_displayed()
     check_dark_mode(html_body, universum_log_element)
     check_timestamps(html_body, universum_log_element)
+
+
+def check_initial_sections_display_state(universum_log_element, steps_body):
+    assert steps_body.is_displayed()
+    sections_expanded_state = {
+        "Success step": False,
+        "Failed step": True,
+        "Partially success step": True,
+        "Partially success step: Success step": False,
+        "Partially success step: Failed step": True,
+        "All success step": False,
+        "All failed step": True,
+        "All failed step: Failed step": True
+    }
+    for section_name, expanded_state in sections_expanded_state.items():
+        assert steps_body.get_section_body_by_name(section_name).is_displayed() == expanded_state
+    assert universum_log_element.get_section_body_by_name("Reporting build result").is_displayed()
+
+
+def check_manual_section_expanding(steps_body):
+    success_step = steps_body.get_section_by_name("Success step")
+    success_step_body = success_step.get_section_body()
+    assert not success_step_body.is_displayed()
+    success_step.click()
+    assert success_step_body.is_displayed()
+    success_step.click()
+    assert not success_step_body.is_displayed()
 
 
 def check_sections_indentation(steps_section):
@@ -106,14 +130,12 @@ def check_sections_indentation(steps_section):
     step_lvl1_second = steps_body.get_section_by_name("Partially success step")
     assert step_lvl1_first.indent == step_lvl1_second.indent
 
-    step_lvl1_second.click()
     step_lvl1_body = step_lvl1_second.get_section_body()
     step_lvl2_first = step_lvl1_body.get_section_by_name("Success step")
     step_lvl2_second = step_lvl1_body.get_section_by_name("Failed step")
     assert step_lvl2_first.indent == step_lvl2_second.indent
 
     assert steps_section.indent < step_lvl1_first.indent < step_lvl2_first.indent
-    step_lvl1_second.click() # restore sections state
 
 
 def check_coloring(body_element, universum_log_element, steps_body):
@@ -132,16 +154,11 @@ def check_body_coloring(body_element):
 def check_title_and_status_coloring(steps_body):
     check_section_coloring(steps_body.get_section_by_name("Success step"))
     check_section_coloring(steps_body.get_section_by_name("Failed step"), is_failed=True)
-    check_section_coloring(steps_body.get_section_by_name("Partially success step"))
+    check_section_coloring(steps_body.get_section_by_name("Partially success step"), has_inner_fail=True)
 
-    composite_step = steps_body.get_section_by_name("Partially success step")
-    composite_step.click()
-    composite_step_body = composite_step.get_section_body()
-
+    composite_step_body = steps_body.get_section_body_by_name("Partially success step")
     check_section_coloring(composite_step_body.get_section_by_name("Success step"))
     check_section_coloring(composite_step_body.get_section_by_name("Failed step"), is_failed=True)
-
-    composite_step.click()  # restore sections state
 
 
 def check_skipped_steps_coloring(steps_body):
@@ -153,10 +170,7 @@ def check_skipped_steps_coloring(steps_body):
 
 
 def check_steps_report_coloring(universum_log_element):
-    report_section = universum_log_element.get_section_by_name("Reporting build result")
-    report_section.click()
-    report_section_body = report_section.get_section_body()
-
+    report_section_body = universum_log_element.get_section_body_by_name("Reporting build result")
     xpath_selector = "./*[text() = 'Success' or text() = 'Failed' or text() = 'Skipped']"
     elements = [TestElement.create(el) for el in report_section_body.find_elements_by_xpath(xpath_selector)]
     assert elements
@@ -168,39 +182,29 @@ def check_steps_report_coloring(universum_log_element):
         else:
             assert False, f"Unexpected element text: '{el.text}'"
 
-    report_section.click() # restore section state
-
 
 def check_errors_tags_coloring(steps_body):
-    step = steps_body.get_section_by_name("Failed step")
-    step_body = step.get_section_body()
-    step.click()
-
+    step_body = steps_body.get_section_body_by_name("Failed step")
     exception_tag = step_body.get_child_by_text("Error:")
     assert exception_tag.color == Color.RED
-
     stderr_tag = step_body.get_child_by_text("stderr:")
     assert stderr_tag.color == Color.YELLOW
 
-    step.click()
+
+def check_section_coloring(step, is_failed=False, has_inner_fail=False):
+    is_section_failed = is_failed or has_inner_fail
+    check_text_item_style(step.get_section_title(), is_section_failed, normal_color=Color.BLUE);
+    if not is_section_failed:
+        step.click() # open section body
+    check_text_item_style(step.get_section_status(), is_failed, normal_color=Color.GREEN);
+    if not is_section_failed:
+        step.click() # close section body
 
 
-def check_section_coloring(step, is_failed=False):
-    check_title_coloring(step.get_section_title())
-    step.click() # open section body
-    check_status_coloring(step.get_section_status(), is_failed)
-    step.click() # close section body
-
-
-def check_title_coloring(title):
-    assert title.color == Color.BLUE
-    check_text_is_bold(title)
-
-
-def check_status_coloring(status, is_failed):
-    exp_color = Color.RED if is_failed else Color.GREEN
-    assert status.color == exp_color
-    check_text_is_bold(status)
+def check_text_item_style(item, is_failed, normal_color):
+    exp_color = Color.RED if is_failed else normal_color
+    assert item.color == exp_color
+    check_text_is_bold(item)
 
 
 def check_text_is_bold(element):
@@ -242,6 +246,9 @@ class TestElement(FirefoxWebElement):
         element.__class__ = TestElement
         return element
 
+    def get_section_body_by_name(self, section_name):
+        return self.get_section_by_name(section_name).get_section_body()
+
     # <any_tag>  <-- self
     #     <input type="checkbox" id="1." class="hide">
     #     <label for="1.">  <-- returning this element
@@ -254,7 +261,7 @@ class TestElement(FirefoxWebElement):
         result = None
         for el in span_elements:
             if section_name in el.text:
-                result = el.find_element_by_xpath("..")
+                return TestElement.create(el.find_element_by_xpath(".."))
         return TestElement.create(result)
 
     # <input type="checkbox" id="1." class="hide">

--- a/universum/modules/output/html_output.css
+++ b/universum/modules/output/html_output.css
@@ -1,0 +1,195 @@
+body {
+    background-color: white;
+    color: black;
+    margin: 0;
+    height: 100%;
+    min-height: 100vh;
+    display: flex;
+}
+
+.time {
+    color: rgba(128, 128, 128, 0.7);
+    display: none;
+}
+.sectionTitle {
+    color: darkslateblue;
+    font-weight: bold;
+}
+.successStatus {
+    color: green;
+    font-weight: bold;
+}
+.failedStatus {
+    color: red;
+    font-weight: bold;
+}
+.skippedStatus {
+    color: red;
+    font-weight: bold;
+}
+.skipped {
+    color: darkcyan;
+}
+.exceptionTag {
+    color: darkred;
+}
+.stderrTag {
+    color: orange;
+}
+
+.hide {
+    display: none;
+}
+.hide + label ~ div {
+    display: none;
+}
+.hide + label {
+    cursor: pointer;
+    display: inline-block;
+}
+.hide:checked + label + div {
+    display: block;
+}
+
+.hide + label + div + .nl {
+    display: block;
+}
+.hide:checked + label + div + .nl::after {
+    display: none;
+}
+
+.hide + label .sectionLbl::before {
+    content: "[+] ";
+}
+.hide:checked + label .sectionLbl::before {
+    content: "[-] ";
+}
+
+#dark-checkbox {
+    display: none;
+}
+
+#time-checkbox {
+    display: none;
+}
+pre {
+    padding: 20px 20px 65px 20px;
+    margin: 0;
+    width: 100%;
+}
+
+#dark-checkbox:checked~pre {
+    background-color: black;
+    color: rgb(219, 198, 198);
+}
+
+#dark-checkbox:checked~pre .sectionTitle {
+    color: #2b7cdf;
+}
+
+#dark-checkbox+label {
+    position: fixed;
+    right: 15px;
+    bottom: 15px;
+    width: 95px;
+    height: 30px;
+    border-radius: 20px;
+    background-color: white;
+    color: gray;
+    border: gray 1px solid;
+    font: 12px sans;
+    cursor: pointer;
+}
+
+#dark-checkbox:checked+label {
+    background-color: black;
+    color: white;
+}
+
+#dark-checkbox+label::before {
+    position: absolute;
+    content: "";
+    height: 22px;
+    width: 22px;
+    left: 4px;
+    bottom: 4px;
+    background-color: gray;
+    transition: .3s;
+    border-radius: 50%;
+}
+
+#dark-checkbox:checked+label::before {
+    background-color: white;
+    transform: translateX(65px);
+}
+
+#dark-checkbox+label::after {
+    content: 'Light';
+    display: block;
+    position: absolute;
+    transform: translate(-50%, -50%);
+    top: 50%;
+    left: 50%;
+}
+
+#dark-checkbox:checked+label::after {
+    content: 'Dark';
+}
+
+#time-checkbox:checked+label~pre .time {
+    display: inline-block;
+}
+
+#time-checkbox+label {
+    position: fixed;
+    right: 125px;
+    bottom: 15px;
+    width: 95px;
+    height: 30px;
+    border-radius: 20px;
+    background-color: white;
+    color: gray;
+    border: gray 1px solid;
+    font: 12px sans;
+    cursor: pointer;
+}
+
+#dark-checkbox:checked~#time-checkbox+label {
+    background-color: black;
+    color: white;
+}
+
+#dark-checkbox:checked~#time-checkbox+label::before {
+    background-color: white;
+}
+
+#time-checkbox:checked+label {
+    background-color: rgb(24, 61, 16) !important;
+    color: white;
+}
+
+#time-checkbox+label::before {
+    position: absolute;
+    content: "";
+    height: 22px;
+    width: 22px;
+    left: 4px;
+    bottom: 4px;
+    background-color: gray;
+    transition: .3s;
+    border-radius: 50%;
+}
+
+#time-checkbox:checked+label::before {
+    background-color: white;
+    transform: translateX(65px);
+}
+
+#time-checkbox+label::after {
+    content: 'Time';
+    display: block;
+    position: absolute;
+    transform: translate(-50%, -50%);
+    top: 50%;
+    left: 50%;
+}

--- a/universum/modules/output/html_output.js
+++ b/universum/modules/output/html_output.js
@@ -1,0 +1,26 @@
+function colorLblsAscendant(el) {
+    if (el == null) {
+        return;
+    }
+    var sectionLbl = el.getElementsByClassName("sectionLbl")[0];
+    sectionLbl.style.color = "red";
+    var innerSpans = sectionLbl.getElementsByTagName("span");
+    if (innerSpans.length > 0) {
+        innerSpans[0].style.cssText = "color:red !important";
+    }
+    sectionLbl.parentElement.previousSibling.checked = true; // expand failed section
+    var parent = el.parentNode;
+    if (parent.tagName != "PRE") {
+        colorLblsAscendant(parent.previousSibling);
+    }
+}
+
+function colorFailedSections() {
+    var results = document.getElementsByClassName("failedStatus");
+    for (var i = 0; i < results.length; i++) {
+        colorLblsAscendant(results[i].parentNode.previousSibling);
+    }
+}
+
+
+colorFailedSections();

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -17,7 +17,7 @@ class HtmlOutput(BaseOutput):
         self.artifact_dir_ready = False
         self._log_buffer = []
         self._block_level = 0
-        self.current_dir = os.path.dirname(os.path.realpath(__file__))
+        self.module_dir = os.path.dirname(os.path.realpath(__file__))
 
     def set_artifact_dir(self, artifact_dir):
         self._filename = os.path.join(artifact_dir, "log.html")
@@ -81,7 +81,7 @@ class HtmlOutput(BaseOutput):
     def log_execution_finish(self, title, version):
         self.log(self._build_execution_finish_msg(title, version))
         html_footer = "</pre>"
-        with open(os.path.join(self.current_dir, "html_output.js"), encoding="utf-8") as js_file:
+        with open(os.path.join(self.module_dir, "html_output.js"), encoding="utf-8") as js_file:
             html_footer += f"<script>{js_file.read()}</script>"
         html_footer += "</body></html>"
         self._log_line(html_footer)
@@ -121,7 +121,7 @@ class HtmlOutput(BaseOutput):
         head = []
         head.append('<meta content="text/html;charset=utf-8" http-equiv="Content-Type">')
         head.append('<meta content="utf-8" http-equiv="encoding">')
-        with open(os.path.join(self.current_dir, "html_output.css"), encoding="utf-8") as css_file:
+        with open(os.path.join(self.module_dir, "html_output.css"), encoding="utf-8") as css_file:
             head.append(f"<style>{css_file.read()}</style>")
         return "".join(head)
 

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -81,7 +81,7 @@ class HtmlOutput(BaseOutput):
     def log_execution_finish(self, title, version):
         self.log(self._build_execution_finish_msg(title, version))
         html_footer = "</pre>"
-        with open(os.path.join(self.current_dir, "html_output.js")) as js_file:
+        with open(os.path.join(self.current_dir, "html_output.js"), encoding="utf-8") as js_file:
             html_footer += f"<script>{js_file.read()}</script>"
         html_footer += "</body></html>"
         self._log_line(html_footer)
@@ -121,7 +121,7 @@ class HtmlOutput(BaseOutput):
         head = []
         head.append('<meta content="text/html;charset=utf-8" http-equiv="Content-Type">')
         head.append('<meta content="utf-8" http-equiv="encoding">')
-        with open(os.path.join(self.current_dir, "html_output.css")) as css_file:
+        with open(os.path.join(self.current_dir, "html_output.css"), encoding="utf-8") as css_file:
             head.append(f"<style>{css_file.read()}</style>")
         return "".join(head)
 

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -17,6 +17,7 @@ class HtmlOutput(BaseOutput):
         self.artifact_dir_ready = False
         self._log_buffer = []
         self._block_level = 0
+        self.current_dir = os.path.dirname(os.path.realpath(__file__))
 
     def set_artifact_dir(self, artifact_dir):
         self._filename = os.path.join(artifact_dir, "log.html")
@@ -79,7 +80,10 @@ class HtmlOutput(BaseOutput):
 
     def log_execution_finish(self, title, version):
         self.log(self._build_execution_finish_msg(title, version))
-        html_footer = "</pre></body></html>"
+        html_footer = "</pre>"
+        with open(os.path.join(self.current_dir, "html_output.js")) as js_file:
+            html_footer += f"<script>{js_file.read()}</script>"
+        html_footer += "</body></html>"
         self._log_line(html_footer)
 
     def _log_line(self, line, with_line_separator=True):
@@ -113,212 +117,15 @@ class HtmlOutput(BaseOutput):
             indent_str.append(" |   ")
         return "".join(indent_str)
 
+    def _build_html_head(self):
+        head = []
+        head.append('<meta content="text/html;charset=utf-8" http-equiv="Content-Type">')
+        head.append('<meta content="utf-8" http-equiv="encoding">')
+        with open(os.path.join(self.current_dir, "html_output.css")) as css_file:
+            head.append(f"<style>{css_file.read()}</style>")
+        return "".join(head)
+
     @staticmethod
     def _build_time_stamp():
         now = datetime.now()
         return now.astimezone().strftime('<span class="time" title="%Z (UTC%z)">%Y-%m-%d %H:%M:%S</span> ')
-
-    @staticmethod
-    def _build_html_head():
-        css_rules = '''
-            body {
-                background-color: white;
-                color: black;
-                margin: 0;
-                height: 100%;
-                min-height: 100vh;
-                display: flex;
-            }
-            
-            .time {
-                color: rgba(128, 128, 128, 0.7);
-                display: none;
-            }
-            .sectionTitle {
-                color: darkslateblue;
-                font-weight: bold;
-            }
-            .successStatus {
-                color: green;
-                font-weight: bold;
-            }
-            .failedStatus {
-                color: red;
-                font-weight: bold;
-            }
-            .skippedStatus {
-                color: red;
-                font-weight: bold;
-            }
-            .skipped {
-                color: darkcyan;
-            }
-            .exceptionTag {
-                color: darkred;
-            }
-            .stderrTag {
-                color: orange;
-            }
-
-            .hide {
-                display: none;
-            }
-            .hide + label ~ div {
-                display: none;
-            }
-            .hide + label {
-                cursor: pointer;
-                display: inline-block;
-            }
-            .hide:checked + label + div {
-                display: block;
-            }
-
-            .hide + label + div + .nl {
-                display: block;
-            }
-            .hide:checked + label + div + .nl::after {
-                display: none;
-            }
-
-            .hide + label .sectionLbl::before {
-                content: "[+] ";
-            }
-            .hide:checked + label .sectionLbl::before {
-                content: "[-] ";
-            }
-
-            #dark-checkbox {
-                display: none;
-            }
-
-            #time-checkbox {
-                display: none;
-            }
-            pre {
-                padding: 20px 20px 65px 20px;
-                margin: 0;
-                width: 100%;
-            }
-
-            #dark-checkbox:checked~pre {
-                background-color: black;
-                color: rgb(219, 198, 198);
-            }
-    
-            #dark-checkbox:checked~pre .sectionTitle {
-                color: #2b7cdf;
-            }
-
-            #dark-checkbox+label {
-                position: fixed;
-                right: 15px;
-                bottom: 15px;
-                width: 95px;
-                height: 30px;
-                border-radius: 20px;
-                background-color: white;
-                color: gray;
-                border: gray 1px solid;
-                font: 12px sans;
-                cursor: pointer;
-            }
-
-            #dark-checkbox:checked+label {
-                background-color: black;
-                color: white;
-            }
-
-            #dark-checkbox+label::before {
-                position: absolute;
-                content: "";
-                height: 22px;
-                width: 22px;
-                left: 4px;
-                bottom: 4px;
-                background-color: gray;
-                transition: .3s;
-                border-radius: 50%;
-            }
-
-            #dark-checkbox:checked+label::before {
-                background-color: white;
-                transform: translateX(65px);
-            }
-
-            #dark-checkbox+label::after {
-                content: 'Light';
-                display: block;
-                position: absolute;
-                transform: translate(-50%, -50%);
-                top: 50%;
-                left: 50%;
-            }
-
-            #dark-checkbox:checked+label::after {
-                content: 'Dark';
-            }
-
-            #time-checkbox:checked+label~pre .time {
-                display: inline-block;
-            }
-    
-            #time-checkbox+label {
-                position: fixed;
-                right: 125px;
-                bottom: 15px;
-                width: 95px;
-                height: 30px;
-                border-radius: 20px;
-                background-color: white;
-                color: gray;
-                border: gray 1px solid;
-                font: 12px sans;
-                cursor: pointer;
-            }
-    
-            #dark-checkbox:checked~#time-checkbox+label {
-                background-color: black;
-                color: white;
-            }
-    
-            #dark-checkbox:checked~#time-checkbox+label::before {
-                background-color: white;
-            }
-    
-            #time-checkbox:checked+label {
-                background-color: rgb(24, 61, 16) !important;
-                color: white;
-            }
-    
-            #time-checkbox+label::before {
-                position: absolute;
-                content: "";
-                height: 22px;
-                width: 22px;
-                left: 4px;
-                bottom: 4px;
-                background-color: gray;
-                transition: .3s;
-                border-radius: 50%;
-            }
-    
-            #time-checkbox:checked+label::before {
-                background-color: white;
-                transform: translateX(65px);
-            }
-    
-            #time-checkbox+label::after {
-                content: 'Time';
-                display: block;
-                position: absolute;
-                transform: translate(-50%, -50%);
-                top: 50%;
-                left: 50%;
-            }
-        '''
-        head = []
-        head.append('<meta content="text/html;charset=utf-8" http-equiv="Content-Type">')
-        head.append('<meta content="utf-8" http-equiv="encoding">')
-        head.append(f"<style>{css_rules}</style>")
-        return "".join(head)


### PR DESCRIPTION
1. On page open all failed sections and their parents will be automatically expanded.
2. CSS and JS sources moved to separate files to clean up the `HtmlOutput` class
    2.1. CSS sources were moved without change
    2.2. JS sources were moved from the old plugin and updated to current needs
![Screenshot 2021-11-09 at 10-49-08 Screenshot](https://user-images.githubusercontent.com/38533734/140892747-3239f8f3-7909-4711-b044-ba3475e27456.png)


