### PR TITLE
feat(output): parametrize HTML log name

### DIFF
--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -61,9 +61,9 @@ def browser():
 
 
 def test_cli_log_custom_name(tmpdir):
-    log_name = "custom_name"
-    artifact_dir = check_cli(tmpdir, ["-hl", log_name])
-    assert os.path.exists(os.path.join(artifact_dir, f"{log_name}.html"))
+    custom_log_name = "custom_name"
+    artifact_dir = check_cli(tmpdir, ["-hl", custom_log_name])
+    assert os.path.exists(os.path.join(artifact_dir, f"{custom_log_name}.html"))
 
 
 def test_cli_log_default_name(tmpdir):

--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -68,7 +68,7 @@ def test_cli_log_custom_name(tmpdir):
 
 def test_cli_log_default_name(tmpdir):
     artifact_dir = check_cli(tmpdir, ["-hl"])
-    assert os.path.exists(os.path.join(artifact_dir, f"universum_log.html"))
+    assert os.path.exists(os.path.join(artifact_dir, "universum_log.html"))
 
 
 def test_cli_no_log_requested(tmpdir):

--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -35,11 +35,13 @@ configs = \
     failed_critical_step + success_step
 """
 
+log_name = "universum_log"
+
 
 def create_environment(test_type, tmpdir):
     env = utils.LocalTestEnvironment(tmpdir, test_type)
     env.configs_file.write(config)
-    env.settings.Output.html_log = True
+    env.settings.Output.html_log_name = log_name
     return env
 
 
@@ -70,14 +72,14 @@ def test_success_clean_build(tmpdir, browser):
 
 
 def test_no_html_log_requested(environment_main_and_nonci):
-    environment_main_and_nonci.settings.Output.html_log = False
+    environment_main_and_nonci.settings.Output.html_log_name = None
     environment_main_and_nonci.run()
-    log_path = os.path.join(environment_main_and_nonci.artifact_dir, "log.html")
-    assert not os.path.exists(log_path)
+    for file_name in os.listdir(environment_main_and_nonci.artifact_dir):
+        assert not file_name.endswith(".html")
 
 
 def check_html_log(artifact_dir, browser):
-    log_path = os.path.join(artifact_dir, "log.html")
+    log_path = os.path.join(artifact_dir, f"{log_name}.html")
     assert os.path.exists(log_path)
 
     browser.get(f"file://{log_path}")

--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -41,7 +41,7 @@ log_name = "universum_log"
 def create_environment(test_type, tmpdir):
     env = utils.LocalTestEnvironment(tmpdir, test_type)
     env.configs_file.write(config)
-    env.settings.Output.html_log_name = log_name
+    env.settings.Output.html_log = log_name
     return env
 
 
@@ -72,7 +72,8 @@ def test_success_clean_build(tmpdir, browser):
 
 
 def test_no_html_log_requested(environment_main_and_nonci):
-    environment_main_and_nonci.settings.Output.html_log_name = None
+    value_if_argument_absent = "disabled"
+    environment_main_and_nonci.settings.Output.html_log = value_if_argument_absent
     environment_main_and_nonci.run()
     for file_name in os.listdir(environment_main_and_nonci.artifact_dir):
         assert not file_name.endswith(".html")

--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -11,6 +11,7 @@ from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.firefox.webelement import FirefoxWebElement
 
+from universum import __main__
 from . import utils
 
 
@@ -59,6 +60,23 @@ def browser():
     firefox.close()
 
 
+def test_cli_log_custom_name(tmpdir):
+    log_name = "custom_name"
+    artifact_dir = check_cli(tmpdir, ["-hl", log_name])
+    assert os.path.exists(os.path.join(artifact_dir, f"{log_name}.html"))
+
+
+def test_cli_log_default_name(tmpdir):
+    artifact_dir = check_cli(tmpdir, ["-hl"])
+    assert os.path.exists(os.path.join(artifact_dir, f"universum_log.html"))
+
+
+def test_cli_no_log_requested(tmpdir):
+    artifact_dir = check_cli(tmpdir, [])
+    for file_name in os.listdir(artifact_dir):
+        assert not file_name.endswith(".html")
+
+
 def test_success(environment_main_and_nonci, browser):
     environment_main_and_nonci.run()
     check_html_log(environment_main_and_nonci.artifact_dir, browser)
@@ -69,14 +87,6 @@ def test_success_clean_build(tmpdir, browser):
     env.settings.Main.clean_build = True
     env.run()
     check_html_log(env.artifact_dir, browser)
-
-
-def test_no_html_log_requested(environment_main_and_nonci):
-    value_if_argument_absent = "disabled"
-    environment_main_and_nonci.settings.Output.html_log = value_if_argument_absent
-    environment_main_and_nonci.run()
-    for file_name in os.listdir(environment_main_and_nonci.artifact_dir):
-        assert not file_name.endswith(".html")
 
 
 def check_html_log(artifact_dir, browser):
@@ -237,6 +247,21 @@ def check_timestamps(body_element, universum_log_element):
     assert delta.days == 0
     assert delta.seconds <= 60
 
+
+def check_cli(tmpdir, html_log_params):
+    artifact_dir = tmpdir.join("artifacts")
+    config_file = tmpdir.join("configs.py")
+    config_file.write_text(config, "utf-8")
+
+    cli_params = ["-vt", "none",
+                  "-fsd", str(tmpdir),
+                  "-cfg", str(config_file),
+                  "-ad", str(artifact_dir)]
+    html_log_params.extend(cli_params)
+    result = __main__.main(html_log_params)
+
+    assert result == 0
+    return artifact_dir
 
 
 class TestElement(FirefoxWebElement):

--- a/universum/modules/artifact_collector.py
+++ b/universum/modules/artifact_collector.py
@@ -94,7 +94,7 @@ class ArtifactCollector(ProjectDirectory, HasOutput, HasStructure):
         if not os.path.exists(self.artifact_dir):
             os.makedirs(self.artifact_dir)
 
-        self.html_output = self.html_output_factory(Output.html_log_default_name)
+        self.html_output = self.html_output_factory()
         self.html_output.set_artifact_dir(self.artifact_dir)
         self.html_output.artifact_dir_ready = False
 

--- a/universum/modules/artifact_collector.py
+++ b/universum/modules/artifact_collector.py
@@ -13,7 +13,7 @@ from ..lib.gravity import Dependency
 from ..lib.utils import make_block
 from ..lib import utils
 from .automation_server import AutomationServerForHostingBuild
-from .output import HasOutput
+from .output import Output, HasOutput
 from .project_directory import ProjectDirectory
 from .reporter import Reporter
 from .structure_handler import HasStructure
@@ -94,7 +94,7 @@ class ArtifactCollector(ProjectDirectory, HasOutput, HasStructure):
         if not os.path.exists(self.artifact_dir):
             os.makedirs(self.artifact_dir)
 
-        self.html_output = self.html_output_factory()
+        self.html_output = self.html_output_factory(Output.html_log_default_name)
         self.html_output.set_artifact_dir(self.artifact_dir)
         self.html_output.artifact_dir_ready = False
 

--- a/universum/modules/artifact_collector.py
+++ b/universum/modules/artifact_collector.py
@@ -13,7 +13,7 @@ from ..lib.gravity import Dependency
 from ..lib.utils import make_block
 from ..lib import utils
 from .automation_server import AutomationServerForHostingBuild
-from .output import Output, HasOutput
+from .output import HasOutput
 from .project_directory import ProjectDirectory
 from .reporter import Reporter
 from .structure_handler import HasStructure

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -11,19 +11,14 @@ __all__ = [
 
 class HtmlOutput(BaseOutput):
 
-    default_log_name = "universum_log"
-
-    def __init__(self, *args, **kwargs):
+    def __init__(self, log_name, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._log_name = self.default_log_name
+        self._log_name = log_name
         self._log_path = None
         self.artifact_dir_ready = False
         self._log_buffer = []
         self._block_level = 0
         self.module_dir = os.path.dirname(os.path.realpath(__file__))
-
-    def set_log_name(self, log_name):
-        self._log_name = log_name
 
     def set_artifact_dir(self, artifact_dir):
         self._log_path = os.path.join(artifact_dir, f"{self._log_name}.html")

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -13,7 +13,7 @@ class HtmlOutput(BaseOutput):
 
     default_name = "universum_log"
 
-    def __init__(self, log_name=default_name, *args, **kwargs):
+    def __init__(self, *args, log_name=default_name, **kwargs):
         super().__init__(*args, **kwargs)
         self._log_name = log_name
         self._log_path = None

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -13,14 +13,18 @@ class HtmlOutput(BaseOutput):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._filename = None
+        self._log_name = "universum_log.html"
+        self._log_path = None
         self.artifact_dir_ready = False
         self._log_buffer = []
         self._block_level = 0
         self.module_dir = os.path.dirname(os.path.realpath(__file__))
 
+    def set_log_name(self, log_name):
+        self._log_name = log_name
+
     def set_artifact_dir(self, artifact_dir):
-        self._filename = os.path.join(artifact_dir, "log.html")
+        self._log_path = os.path.join(artifact_dir, f"{self._log_name}.html")
 
     def open_block(self, num_str, name):
         opening_html = f'<input type="checkbox" id="{num_str}" class="hide"/>' + \
@@ -92,7 +96,7 @@ class HtmlOutput(BaseOutput):
         self._log_buffered(self._build_time_stamp() + self._build_indent() + line)
 
     def _log_buffered(self, line):
-        if not self._filename:
+        if not self._log_path:
             raise RuntimeError("Artifact directory was not set")
         if not self.artifact_dir_ready:
             self._log_buffer.append(line)
@@ -107,7 +111,7 @@ class HtmlOutput(BaseOutput):
         self._log_buffer = []
 
     def _write_to_file(self, line):
-        with open(self._filename, "a", encoding="utf-8") as file:
+        with open(self._log_path, "a", encoding="utf-8") as file:
             file.write(line)
 
     def _build_indent(self):

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -11,7 +11,9 @@ __all__ = [
 
 class HtmlOutput(BaseOutput):
 
-    def __init__(self, log_name, *args, **kwargs):
+    default_name = "universum_log"
+
+    def __init__(self, log_name=default_name, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._log_name = log_name
         self._log_path = None

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -11,9 +11,11 @@ __all__ = [
 
 class HtmlOutput(BaseOutput):
 
+    default_log_name = "universum_log"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._log_name = "universum_log.html"
+        self._log_name = self.default_log_name
         self._log_path = None
         self.artifact_dir_ready = False
         self._log_buffer = []

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -104,7 +104,7 @@ class Output(Module):
 
     def _create_html_driver(self):
         is_enabled = self.settings.html_log != self.html_log_disabled_arg_value
-        html_driver = self.html_driver_factory(self.settings.html_log) if is_enabled else None
+        html_driver = self.html_driver_factory(log_name=self.settings.html_log) if is_enabled else None
         handler = HtmlDriverHandler(html_driver)
         return handler
 

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -22,8 +22,7 @@ class Output(Module):
     terminal_driver_factory = Dependency(TerminalBasedOutput)
     html_driver_factory = Dependency(HtmlOutput)
 
-    html_log_default_name = "universum_log"
-    html_log_disabled_arg_value = "disabled"
+    html_log_disabled_arg_value = "__html_log_disabled_arg_value"
 
     @staticmethod
     def define_arguments(argument_parser):
@@ -36,7 +35,7 @@ class Output(Module):
         # `universum -hl` -> html_log == const
         # `universum -hl custom` -> html_log == custom
         parser.add_argument("--html-log", "-hl",
-                            nargs="?", const=Output.html_log_default_name, default=Output.html_log_disabled_arg_value,
+                            nargs="?", const=HtmlOutput.default_name, default=Output.html_log_disabled_arg_value,
                             help="Generate self-contained HTML log in artifacts directory. "
                                  "You may specify a file name in this parameter's value or default "
                                  "one will be used")

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -22,6 +22,7 @@ class Output(Module):
     terminal_driver_factory = Dependency(TerminalBasedOutput)
     html_driver_factory = Dependency(HtmlOutput)
 
+    html_log_default_name = "universum_log"
     html_log_disabled_arg_value = "disabled"
 
     @staticmethod
@@ -35,7 +36,7 @@ class Output(Module):
         # `universum -hl` -> html_log == const
         # `universum -hl custom` -> html_log == custom
         parser.add_argument("--html-log", "-hl",
-                            nargs="?", const=HtmlOutput.default_log_name, default=Output.html_log_disabled_arg_value,
+                            nargs="?", const=Output.html_log_default_name, default=Output.html_log_disabled_arg_value,
                             help="Generate self-contained HTML log in artifacts directory. "
                                  "You may specify a file name in this parameter's value or default "
                                  "one will be used")
@@ -104,9 +105,8 @@ class Output(Module):
 
     def _create_html_driver(self):
         is_enabled = self.settings.html_log != self.html_log_disabled_arg_value
-        html_driver = self.html_driver_factory() if is_enabled else None
+        html_driver = self.html_driver_factory(self.settings.html_log) if is_enabled else None
         handler = HtmlDriverHandler(html_driver)
-        handler.set_log_name(self.settings.html_log)
         return handler
 
 

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -29,8 +29,9 @@ class Output(Module):
                             help="Type of output to produce (tc - TeamCity, jenkins - Jenkins, term - terminal). "
                                  "TeamCity and Jenkins environments are detected automatically when launched on build "
                                  "agent.")
-        parser.add_argument("--html-log", "-hl", action="store_true", default=False,
-                            help="Generate self-contained HTML log in artifacts directory")
+        parser.add_argument("--html-log-name", "-hln",
+                            help="Generate self-contained HTML log in artifacts directory, "
+                                 "store in ${html_log_name}.html file")
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -95,8 +96,10 @@ class Output(Module):
         self.html_driver.log_execution_finish(title, version)
 
     def _create_html_driver(self):
-        html_driver = self.html_driver_factory() if self.settings.html_log else None
-        return HtmlDriverHandler(html_driver)
+        html_driver = self.html_driver_factory() if self.settings.html_log_name else None
+        handler = HtmlDriverHandler(html_driver)
+        handler.set_log_name(self.settings.html_log_name)
+        return handler
 
 
 

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -35,7 +35,7 @@ class Output(Module):
         # `universum -hl` -> html_log == const
         # `universum -hl custom` -> html_log == custom
         parser.add_argument("--html-log", "-hl",
-                            nargs="?", const="universum_log", default=Output.html_log_disabled_arg_value,
+                            nargs="?", const=HtmlOutput.default_log_name, default=Output.html_log_disabled_arg_value,
                             help="Generate self-contained HTML log in artifacts directory. "
                                  "You may specify a file name in this parameter's value or default "
                                  "one will be used")

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -22,6 +22,8 @@ class Output(Module):
     terminal_driver_factory = Dependency(TerminalBasedOutput)
     html_driver_factory = Dependency(HtmlOutput)
 
+    html_log_disabled_arg_value = "disabled"
+
     @staticmethod
     def define_arguments(argument_parser):
         parser = argument_parser.get_or_create_group("Output", "Log appearance parameters")
@@ -29,9 +31,14 @@ class Output(Module):
                             help="Type of output to produce (tc - TeamCity, jenkins - Jenkins, term - terminal). "
                                  "TeamCity and Jenkins environments are detected automatically when launched on build "
                                  "agent.")
-        parser.add_argument("--html-log-name", "-hln",
-                            help="Generate self-contained HTML log in artifacts directory, "
-                                 "store in ${html_log_name}.html file")
+        # `universum` -> html_log == default
+        # `universum -hl` -> html_log == const
+        # `universum -hl custom` -> html_log == custom
+        parser.add_argument("--html-log", "-hl",
+                            nargs="?", const="universum_log", default=Output.html_log_disabled_arg_value,
+                            help="Generate self-contained HTML log in artifacts directory. "
+                                 "You may specify a file name in this parameter's value or default "
+                                 "one will be used")
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -96,9 +103,10 @@ class Output(Module):
         self.html_driver.log_execution_finish(title, version)
 
     def _create_html_driver(self):
-        html_driver = self.html_driver_factory() if self.settings.html_log_name else None
+        is_enabled = self.settings.html_log != self.html_log_disabled_arg_value
+        html_driver = self.html_driver_factory() if is_enabled else None
         handler = HtmlDriverHandler(html_driver)
-        handler.set_log_name(self.settings.html_log_name)
+        handler.set_log_name(self.settings.html_log)
         return handler
 
 

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -22,7 +22,7 @@ class Output(Module):
     terminal_driver_factory = Dependency(TerminalBasedOutput)
     html_driver_factory = Dependency(HtmlOutput)
 
-    html_log_disabled_arg_value = "__html_log_disabled_arg_value"
+    html_log_disabled_arg_value = None
 
     @staticmethod
     def define_arguments(argument_parser):


### PR DESCRIPTION
**Before**:
    1. `python3 -m universum` - HTML log disabled
    2. `python3 -m universum --html-log` - HTML log saved to file with the default name 
**Now**:
    + one more option 
    3. `python3 -m universum --html-log custom` - HTML log saved to file with the custom name