### PR TITLE
Add Github Actions output support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ class FuzzyCallChecker:
 
 @pytest.fixture()
 def stdout_checker(request):
-    with mock.patch('universum.modules.output.terminal_based_output.stdout') as logging_mock:
+    with mock.patch('universum.modules.output.terminal_based_output.TerminalBasedOutput.stdout') as logging_mock:
         result = FuzzyCallChecker(logging_mock)
         yield result
 

--- a/universum/lib/utils.py
+++ b/universum/lib/utils.py
@@ -57,29 +57,35 @@ def detect_environment() -> str:
     """
     :return: "tc" if the script is launched on TeamCity agent,
              "jenkins" is launched on Jenkins agent,
+             "github" is launched on Github Actions agent,
              "terminal" otherwise
     """
     teamcity = "TEAMCITY_VERSION" in os.environ
     jenkins = "JENKINS_HOME" in os.environ
     pycharm = "PYCHARM_HOSTED" in os.environ
+    github = "GITHUB_WORKFLOW" in os.environ
     if pycharm:
         return "terminal"
     if teamcity and not jenkins:
         return "tc"
     if not teamcity and jenkins:
         return "jenkins"
+    if github:
+        return "github"
     return "terminal"
 
 
 LocalFactoryT = TypeVar('LocalFactoryT', bound=Module)
 TeamcityFactoryT = TypeVar('TeamcityFactoryT', bound=Module)
 JenkinsFactoryT = TypeVar('JenkinsFactoryT', bound=Module)
+GithubFactoryT = TypeVar('GithubFactoryT', bound=Module)
 
 
 def create_driver(local_factory: Callable[[], LocalFactoryT],
                   teamcity_factory: Callable[[], TeamcityFactoryT],
                   jenkins_factory: Callable[[], JenkinsFactoryT],
-                  env_type: str = "") -> Union[LocalFactoryT, TeamcityFactoryT, JenkinsFactoryT]:
+                  github_factory:  Callable[[], GithubFactoryT],
+                  env_type: str = "") -> Union[LocalFactoryT, TeamcityFactoryT, JenkinsFactoryT, GithubFactoryT]:
     if not env_type:
         env_type = detect_environment()
 
@@ -87,6 +93,8 @@ def create_driver(local_factory: Callable[[], LocalFactoryT],
         return teamcity_factory()
     if env_type == "jenkins":
         return jenkins_factory()
+    if env_type == "github":
+        return github_factory()
     return local_factory()
 
 

--- a/universum/lib/utils.py
+++ b/universum/lib/utils.py
@@ -57,7 +57,7 @@ def detect_environment() -> str:
     """
     :return: "tc" if the script is launched on TeamCity agent,
              "jenkins" is launched on Jenkins agent,
-             "github" is launched on Github Actions agent,
+             "github" is launched on Github Actions,
              "terminal" otherwise
     """
     teamcity = "TEAMCITY_VERSION" in os.environ

--- a/universum/modules/automation_server/automation_server.py
+++ b/universum/modules/automation_server/automation_server.py
@@ -35,6 +35,7 @@ class AutomationServerForHostingBuild(AutomationServer):
         self.driver: BaseServerForHostingBuild = \
             utils.create_driver(teamcity_factory=self.teamcity_driver_factory,
                                 jenkins_factory=self.jenkins_driver_factory,
+                                github_factory=self.local_driver_factory,
                                 local_factory=self.local_driver_factory,
                                 env_type=self.settings.type)
 
@@ -58,6 +59,7 @@ class AutomationServerForTrigger(AutomationServer):
         self.driver: BaseServerForTrigger = \
             utils.create_driver(teamcity_factory=self.teamcity_driver_factory,
                                 jenkins_factory=self.jenkins_driver_factory,
+                                github_factory=self.local_driver_factory,
                                 local_factory=self.local_driver_factory,
                                 env_type=self.settings.type)
 

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -1,6 +1,22 @@
 from ...lib.gravity import Module
 
 
+__all__ = [
+    "BaseOutput",
+    "TermColors"
+]
+
+
+class TermColors:
+    red = "\033[1;31m"
+    dark_red = "\033[0;31m"
+    green = "\033[1;32m"
+    blue = "\033[1;34m"
+    dark_cyan = "\033[0;36m"
+    dark_yellow = "\033[0;33m"
+    reset = "\033[00m"
+
+
 class BaseOutput(Module):
     """
     Abstract base class for output drivers

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -1,22 +1,6 @@
 from ...lib.gravity import Module
 
 
-__all__ = [
-    "BaseOutput",
-    "TermColors"
-]
-
-
-class TermColors:
-    red = "\033[1;31m"
-    dark_red = "\033[0;31m"
-    green = "\033[1;32m"
-    blue = "\033[1;34m"
-    dark_cyan = "\033[0;36m"
-    dark_yellow = "\033[0;33m"
-    reset = "\033[00m"
-
-
 class BaseOutput(Module):
     """
     Abstract base class for output drivers

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -8,6 +8,7 @@ __all__ = [
 class GithubOutput(BaseOutput):
     """
     GitHub doesn't support nested grouping
+    See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
     """
 
     def __init__(self, *args, **kwargs):

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -8,7 +8,7 @@ __all__ = [
 class GithubOutput(BaseOutput):
     """
     GitHub doesn't support nested grouping
-    See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
+    See: https://github.com/actions/runner/issues/802
     """
 
     def __init__(self, *args, **kwargs):

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -1,4 +1,4 @@
-from .base_output import BaseOutput, TermColors
+from .base_output import BaseOutput
 
 __all__ = [
     "GithubOutput"
@@ -36,16 +36,6 @@ class GithubOutput(BaseOutput):
         lines = message.splitlines(False)
         for single_line in lines:
             print(f"::warning::{single_line}")
-
-    def report_step(self, message, status):
-        color = TermColors.red
-        if status.lower() == "success":
-            color = TermColors.green
-
-        if message.endswith(status):
-            message = message[:-len(status)]
-            message += color + status + TermColors.reset
-        self.log(message)
 
     def change_status(self, message):
         pass

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -1,4 +1,4 @@
-from .terminal_based_output import TerminalBasedOutput, stdout
+from .terminal_based_output import TerminalBasedOutput
 
 __all__ = [
     "GithubOutput"
@@ -7,20 +7,20 @@ __all__ = [
 
 class GithubOutput(TerminalBasedOutput):
     """
-    GitHub doesn't support nested grouping
-    See: https://github.com/actions/runner/issues/802
+    Github Actions manual: https://docs.github.com/en/actions
+    GitHub doesn't support nested grouping (https://github.com/actions/runner/issues/802)
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._block_opened = False
 
-    # pylint: disable = arguments-differ
-    def print_lines(self, *args, prefix=""):
-        result = ''.join(args)
+    def print_lines(self, *args, **kwargs):
+        prefix = kwargs.setdefault("prefix", "")
+        result = "".join(args)
         lines = result.splitlines(False)
         for line in lines:
-            stdout(f"{prefix}{line}")
+            self.stdout(f"{prefix}{line}")
 
     def open_block(self, num_str, name):
         if self._block_opened:
@@ -35,7 +35,7 @@ class GithubOutput(TerminalBasedOutput):
             self.print_lines("::endgroup::")
 
         if status == "Failed":
-            self.print_lines(f'::error::{num_str} {name} - Failed')
+            self.print_lines(f"::error::{num_str} {name} - Failed")
 
     def report_skipped(self, message):
         self.print_lines(message, prefix="::warning::")

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -27,7 +27,7 @@ class GithubOutput(BaseOutput):
             print("::endgroup::")
 
         if status == "Failed":
-            print(f'::error::{num_str} {name} [Failed]')
+            print(f'::error::{num_str} {name} - Failed')
 
     def report_error(self, description):
         pass
@@ -36,6 +36,12 @@ class GithubOutput(BaseOutput):
         lines = message.splitlines(False)
         for single_line in lines:
             print(f"::warning::{single_line}")
+
+    def report_step(self, message, status):
+        if status == "Failed":
+            print(f'::error::{message}')
+        else:
+            print(message)
 
     def change_status(self, message):
         pass

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -1,4 +1,4 @@
-from .terminal_based_output import TerminalBasedOutput
+from .terminal_based_output import TerminalBasedOutput, stdout
 
 __all__ = [
     "GithubOutput"
@@ -20,7 +20,7 @@ class GithubOutput(TerminalBasedOutput):
         result = ''.join(args)
         lines = result.splitlines(False)
         for line in lines:
-            self.stdout(f"{prefix}{line}")
+            stdout(f"{prefix}{line}")
 
     def open_block(self, num_str, name):
         if self._block_opened:

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -1,4 +1,4 @@
-from .terminal_based_output import TerminalBasedOutput, stdout
+from .terminal_based_output import TerminalBasedOutput
 
 __all__ = [
     "GithubOutput"
@@ -15,11 +15,12 @@ class GithubOutput(TerminalBasedOutput):
         super().__init__(*args, **kwargs)
         self._block_opened = False
 
+    # pylint: disable = arguments-differ
     def print_lines(self, *args, prefix=""):
         result = ''.join(args)
         lines = result.splitlines(False)
         for line in lines:
-            stdout(f"{prefix}{line}")
+            self.stdout(f"{prefix}{line}")
 
     def open_block(self, num_str, name):
         if self._block_opened:

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -14,15 +14,12 @@ class GithubOutput(TerminalBasedOutput):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._block_opened = False
-        self.prefix = None
 
-    def print_lines(self, *args):
+    def print_lines(self, *args, prefix=""):
         result = ''.join(args)
         lines = result.splitlines(False)
         for line in lines:
-            if self.prefix:
-                line = f"{self.prefix}{line}"
-            stdout(line)
+            stdout(f"{prefix}{line}")
 
     def open_block(self, num_str, name):
         if self._block_opened:
@@ -40,22 +37,10 @@ class GithubOutput(TerminalBasedOutput):
             self.print_lines(f'::error::{num_str} {name} - Failed')
 
     def report_skipped(self, message):
-        try:
-            self.prefix = "::warning::"
-            super().report_skipped(message)
-        finally:
-            self.prefix = None
+        self.print_lines(message, prefix="::warning::")
 
     def log_exception(self, line):
-        try:
-            self.prefix = "::error::"
-            super().log_exception(line)
-        finally:
-            self.prefix = None
+        self.print_lines(line, prefix="::error::")
 
     def log_stderr(self, line):
-        try:
-            self.prefix = "::warning::"
-            super().log_stderr(line)
-        finally:
-            self.prefix = None
+        self.print_lines("stderr: ", line, prefix="::warning::")

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -37,12 +37,6 @@ class GithubOutput(BaseOutput):
         for single_line in lines:
             print(f"::warning::{single_line}")
 
-    def report_step(self, message, status):
-        if status == "Failed":
-            print(f'::error::{message}')
-        else:
-            print(message)
-
     def change_status(self, message):
         pass
 

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -1,4 +1,4 @@
-from .base_output import BaseOutput
+from .base_output import BaseOutput, TermColors
 
 __all__ = [
     "GithubOutput"
@@ -36,6 +36,16 @@ class GithubOutput(BaseOutput):
         lines = message.splitlines(False)
         for single_line in lines:
             print(f"::warning::{single_line}")
+
+    def report_step(self, message, status):
+        color = TermColors.red
+        if status.lower() == "success":
+            color = TermColors.green
+
+        if message.endswith(status):
+            message = message[:-len(status)]
+            message += color + status + TermColors.reset
+        self.log(message)
 
     def change_status(self, message):
         pass

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -6,6 +6,10 @@ __all__ = [
 
 
 class GithubOutput(BaseOutput):
+    """
+    GitHub doesn't support nested grouping
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._block_opened = False
@@ -24,8 +28,6 @@ class GithubOutput(BaseOutput):
 
         if status == "Failed":
             print(f'::error::{num_str} {name} [Failed]')
-        else:
-            print(f'{num_str} {name} [Success]')
 
     def report_error(self, description):
         pass
@@ -34,9 +36,6 @@ class GithubOutput(BaseOutput):
         lines = message.splitlines(False)
         for single_line in lines:
             print(f"::warning::{single_line}")
-
-    # def report_step(self, message, status):
-    #     self.log(message)
 
     def change_status(self, message):
         pass

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -1,0 +1,61 @@
+from .base_output import BaseOutput
+
+__all__ = [
+    "GithubOutput"
+]
+
+
+class GithubOutput(BaseOutput):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._block_opened = False
+
+    def open_block(self, num_str, name):
+        if self._block_opened:
+            print("::endgroup::")
+
+        print(f"::group::{num_str} {name}")
+        self._block_opened = True
+
+    def close_block(self, num_str, name, status):
+        if self._block_opened:
+            self._block_opened = False
+            print("::endgroup::")
+
+        if status == "Failed":
+            print(f'::error::{num_str} {name} [Failed]')
+        else:
+            print(f'{num_str} {name} [Success]')
+
+    def report_error(self, description):
+        pass
+
+    def report_skipped(self, message):
+        lines = message.splitlines(False)
+        for single_line in lines:
+            print(f"::warning::{single_line}")
+
+    # def report_step(self, message, status):
+    #     self.log(message)
+
+    def change_status(self, message):
+        pass
+
+    def log_exception(self, line):
+        lines = line.splitlines(False)
+        for single_line in lines:
+            print(f"::error::{single_line}")
+
+    def log_stderr(self, line):
+        lines = line.splitlines(False)
+        for single_line in lines:
+            print(f"::warning::stderr: {single_line}")
+
+    def log(self, line):
+        print("==>", line)
+
+    def log_external_command(self, command):
+        print("$", command)
+
+    def log_shell_output(self, line):
+        print(line)

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -29,8 +29,8 @@ class Output(Module):
         parser = argument_parser.get_or_create_group("Output", "Log appearance parameters")
         parser.add_argument("--out-type", "-ot", dest="type", choices=["tc", "term", "jenkins", "github"],
                             help="Type of output to produce (tc - TeamCity, jenkins - Jenkins, term - terminal, "
-                                 "github - Github Actions). TeamCity and Jenkins environments are detected "
-                                 "automatically when launched on build agent.")
+                                 "github - Github Actions). TeamCity, Jenkins and Github Actions environments are "
+                                 "detected automatically when launched on build agent.")
         # `universum` -> html_log == default
         # `universum -hl` -> html_log == const
         # `universum -hl custom` -> html_log == custom

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Optional
 from ...lib.gravity import Module, Dependency
 from ...lib import utils
 from .base_output import BaseOutput
+from .github_output import GithubOutput
 from .terminal_based_output import TerminalBasedOutput
 from .teamcity_output import TeamcityOutput
 from .html_output import HtmlOutput
@@ -21,14 +22,15 @@ class Output(Module):
     teamcity_driver_factory = Dependency(TeamcityOutput)
     terminal_driver_factory = Dependency(TerminalBasedOutput)
     html_driver_factory = Dependency(HtmlOutput)
+    github_driver_factory = Dependency(GithubOutput)
 
     @staticmethod
     def define_arguments(argument_parser):
         parser = argument_parser.get_or_create_group("Output", "Log appearance parameters")
-        parser.add_argument("--out-type", "-ot", dest="type", choices=["tc", "term", "jenkins"],
-                            help="Type of output to produce (tc - TeamCity, jenkins - Jenkins, term - terminal). "
-                                 "TeamCity and Jenkins environments are detected automatically "
-                                 "when launched on build agent.")
+        parser.add_argument("--out-type", "-ot", dest="type", choices=["tc", "term", "jenkins", "github"],
+                            help="Type of output to produce (tc - TeamCity, jenkins - Jenkins, term - terminal, "
+                                 "github - Github Actions). TeamCity and Jenkins environments are detected "
+                                 "automatically when launched on build agent.")
         # `universum` -> html_log == default
         # `universum -hl` -> html_log == const
         # `universum -hl custom` -> html_log == custom
@@ -43,6 +45,7 @@ class Output(Module):
             utils.create_driver(local_factory=self.terminal_driver_factory,
                                 teamcity_factory=self.teamcity_driver_factory,
                                 jenkins_factory=self.terminal_driver_factory,
+                                github_factory=self.github_driver_factory,
                                 env_type=self.settings.type)
         self.html_driver = self._create_html_driver()
 

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -4,7 +4,6 @@ import sys
 from .base_output import BaseOutput
 
 __all__ = [
-    "stdout",
     "TerminalBasedOutput"
 ]
 
@@ -19,32 +18,32 @@ class Colors:
     reset = "\033[00m"
 
 
-def stdout(*args, **kwargs):
-    sys.stdout.write(''.join(args))
-    if not kwargs.get("no_enter", False):
-        sys.stdout.write('\n')
-
-
 class TerminalBasedOutput(BaseOutput):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.block_level = 0
         self.unicode_acceptable = (locale.getpreferredencoding() == "UTF-8")
 
+    @staticmethod
+    def stdout(*args, **kwargs):
+        sys.stdout.write(''.join(args))
+        if not kwargs.get("no_enter", False):
+            sys.stdout.write('\n')
+
     def indent(self):
         for x in range(0, self.block_level):
-            stdout("  " * x, " |   ", no_enter=True)
+            self.stdout("  " * x, " |   ", no_enter=True)
 
     def print_lines(self, *args):
         result = ''.join(args)
         lines = result.splitlines(False)
         for line in lines:
             self.indent()
-            stdout(line)
+            self.stdout(line)
 
     def open_block(self, num_str, name):
         self.indent()
-        stdout(num_str, ' ', Colors.blue, name, Colors.reset)
+        self.stdout(num_str, ' ', Colors.blue, name, Colors.reset)
         self.block_level += 1
 
     def close_block(self, num_str, name, status):
@@ -56,11 +55,11 @@ class TerminalBasedOutput(BaseOutput):
             block_end = " | "
 
         if status == "Failed":
-            stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
+            self.stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
         else:
-            stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
+            self.stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
         self.indent()
-        stdout()
+        self.stdout()
 
     def report_error(self, description):
         pass

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -4,7 +4,6 @@ import sys
 from .base_output import BaseOutput
 
 __all__ = [
-    "stdout",
     "TerminalBasedOutput"
 ]
 
@@ -19,32 +18,32 @@ class Colors:
     reset = "\033[00m"
 
 
-def stdout(*args, **kwargs):
-    sys.stdout.write(''.join(args))
-    if not kwargs.get("no_enter", False):
-        sys.stdout.write('\n')
-
-
 class TerminalBasedOutput(BaseOutput):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.block_level = 0
         self.unicode_acceptable = (locale.getpreferredencoding() == "UTF-8")
 
+    @staticmethod
+    def stdout(*args, **kwargs):
+        sys.stdout.write(''.join(args))
+        if not kwargs.get("no_enter", False):
+            sys.stdout.write('\n')
+
     def indent(self):
         for x in range(0, self.block_level):
-            stdout("  " * x, " |   ", no_enter=True)
+            self.stdout("  " * x, " |   ", no_enter=True)
 
-    def print_lines(self, *args):
+    def print_lines(self, *args, **kwargs):
         result = ''.join(args)
         lines = result.splitlines(False)
         for line in lines:
             self.indent()
-            stdout(line)
+            self.stdout(line)
 
     def open_block(self, num_str, name):
         self.indent()
-        stdout(num_str, ' ', Colors.blue, name, Colors.reset)
+        self.stdout(num_str, ' ', Colors.blue, name, Colors.reset)
         self.block_level += 1
 
     def close_block(self, num_str, name, status):
@@ -56,11 +55,11 @@ class TerminalBasedOutput(BaseOutput):
             block_end = " | "
 
         if status == "Failed":
-            stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
+            self.stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
         else:
-            stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
+            self.stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
         self.indent()
-        stdout()
+        self.stdout()
 
     def report_error(self, description):
         pass

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -1,11 +1,21 @@
 import locale
 import sys
 
-from .base_output import BaseOutput, TermColors
+from .base_output import BaseOutput
 
 __all__ = [
     "TerminalBasedOutput"
 ]
+
+
+class Colors:
+    red = "\033[1;31m"
+    dark_red = "\033[0;31m"
+    green = "\033[1;32m"
+    blue = "\033[1;34m"
+    dark_cyan = "\033[0;36m"
+    dark_yellow = "\033[0;33m"
+    reset = "\033[00m"
 
 
 def stdout(*args, **kwargs):
@@ -33,7 +43,7 @@ class TerminalBasedOutput(BaseOutput):
 
     def open_block(self, num_str, name):
         self.indent()
-        stdout(num_str, ' ', TermColors.blue, name, TermColors.reset)
+        stdout(num_str, ' ', Colors.blue, name, Colors.reset)
         self.block_level += 1
 
     def close_block(self, num_str, name, status):
@@ -45,9 +55,9 @@ class TerminalBasedOutput(BaseOutput):
             block_end = " | "
 
         if status == "Failed":
-            stdout(self.block_level * "  ", block_end, TermColors.red, "[Failed]", TermColors.reset)
+            stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
         else:
-            stdout(self.block_level * "  ", block_end, TermColors.green, "[Success]", TermColors.reset)
+            stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
         self.indent()
         stdout()
 
@@ -55,26 +65,26 @@ class TerminalBasedOutput(BaseOutput):
         pass
 
     def report_skipped(self, message):
-        self.print_lines(TermColors.dark_cyan, message, TermColors.reset)
+        self.print_lines(Colors.dark_cyan, message, Colors.reset)
 
     def report_step(self, message, status):
-        color = TermColors.red
+        color = Colors.red
         if status.lower() == "success":
-            color = TermColors.green
+            color = Colors.green
 
         if message.endswith(status):
             message = message[:-len(status)]
-            message += color + status + TermColors.reset
+            message += color + status + Colors.reset
         self.log(message)
 
     def change_status(self, message):
         pass
 
     def log_exception(self, line):
-        self.print_lines(TermColors.dark_red, "Error: ", TermColors.reset, line)
+        self.print_lines(Colors.dark_red, "Error: ", Colors.reset, line)
 
     def log_stderr(self, line):
-        self.print_lines(TermColors.dark_yellow, "stderr: ", TermColors.reset, line)
+        self.print_lines(Colors.dark_yellow, "stderr: ", Colors.reset, line)
 
     def log(self, line):
         self.print_lines("==> ", line)

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -4,6 +4,7 @@ import sys
 from .base_output import BaseOutput
 
 __all__ = [
+    "stdout",
     "TerminalBasedOutput"
 ]
 
@@ -18,32 +19,32 @@ class Colors:
     reset = "\033[00m"
 
 
+def stdout(*args, **kwargs):
+    sys.stdout.write(''.join(args))
+    if not kwargs.get("no_enter", False):
+        sys.stdout.write('\n')
+
+
 class TerminalBasedOutput(BaseOutput):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.block_level = 0
         self.unicode_acceptable = (locale.getpreferredencoding() == "UTF-8")
 
-    @staticmethod
-    def stdout(*args, **kwargs):
-        sys.stdout.write(''.join(args))
-        if not kwargs.get("no_enter", False):
-            sys.stdout.write('\n')
-
     def indent(self):
         for x in range(0, self.block_level):
-            self.stdout("  " * x, " |   ", no_enter=True)
+            stdout("  " * x, " |   ", no_enter=True)
 
     def print_lines(self, *args):
         result = ''.join(args)
         lines = result.splitlines(False)
         for line in lines:
             self.indent()
-            self.stdout(line)
+            stdout(line)
 
     def open_block(self, num_str, name):
         self.indent()
-        self.stdout(num_str, ' ', Colors.blue, name, Colors.reset)
+        stdout(num_str, ' ', Colors.blue, name, Colors.reset)
         self.block_level += 1
 
     def close_block(self, num_str, name, status):
@@ -55,11 +56,11 @@ class TerminalBasedOutput(BaseOutput):
             block_end = " | "
 
         if status == "Failed":
-            self.stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
+            stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
         else:
-            self.stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
+            stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
         self.indent()
-        self.stdout()
+        stdout()
 
     def report_error(self, description):
         pass

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -4,6 +4,7 @@ import sys
 from .base_output import BaseOutput
 
 __all__ = [
+    "stdout",
     "TerminalBasedOutput"
 ]
 

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -1,21 +1,11 @@
 import locale
 import sys
 
-from .base_output import BaseOutput
+from .base_output import BaseOutput, TermColors
 
 __all__ = [
     "TerminalBasedOutput"
 ]
-
-
-class Colors:
-    red = "\033[1;31m"
-    dark_red = "\033[0;31m"
-    green = "\033[1;32m"
-    blue = "\033[1;34m"
-    dark_cyan = "\033[0;36m"
-    dark_yellow = "\033[0;33m"
-    reset = "\033[00m"
 
 
 def stdout(*args, **kwargs):
@@ -43,7 +33,7 @@ class TerminalBasedOutput(BaseOutput):
 
     def open_block(self, num_str, name):
         self.indent()
-        stdout(num_str, ' ', Colors.blue, name, Colors.reset)
+        stdout(num_str, ' ', TermColors.blue, name, TermColors.reset)
         self.block_level += 1
 
     def close_block(self, num_str, name, status):
@@ -55,9 +45,9 @@ class TerminalBasedOutput(BaseOutput):
             block_end = " | "
 
         if status == "Failed":
-            stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
+            stdout(self.block_level * "  ", block_end, TermColors.red, "[Failed]", TermColors.reset)
         else:
-            stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
+            stdout(self.block_level * "  ", block_end, TermColors.green, "[Success]", TermColors.reset)
         self.indent()
         stdout()
 
@@ -65,26 +55,26 @@ class TerminalBasedOutput(BaseOutput):
         pass
 
     def report_skipped(self, message):
-        self.print_lines(Colors.dark_cyan, message, Colors.reset)
+        self.print_lines(TermColors.dark_cyan, message, TermColors.reset)
 
     def report_step(self, message, status):
-        color = Colors.red
+        color = TermColors.red
         if status.lower() == "success":
-            color = Colors.green
+            color = TermColors.green
 
         if message.endswith(status):
             message = message[:-len(status)]
-            message += color + status + Colors.reset
+            message += color + status + TermColors.reset
         self.log(message)
 
     def change_status(self, message):
         pass
 
     def log_exception(self, line):
-        self.print_lines(Colors.dark_red, "Error: ", Colors.reset, line)
+        self.print_lines(TermColors.dark_red, "Error: ", TermColors.reset, line)
 
     def log_stderr(self, line):
-        self.print_lines(Colors.dark_yellow, "stderr: ", Colors.reset, line)
+        self.print_lines(TermColors.dark_yellow, "stderr: ", TermColors.reset, line)
 
     def log(self, line):
         self.print_lines("==> ", line)


### PR DESCRIPTION
# Description

Add Github Actions out type support.

The main goal of these changes is to add support for grouping logs to the Github Action.
At the moment, github does not support nested logs, so the beginning of each new block of logs closes the previous one. 
If the block ends with an error, a error message is displayed.


Resolves #(issue) None

# How Has This Been Tested?

See result on Github Actions:
https://github.com/dogbert911/universum_test/runs/5246061477?check_suite_focus=true

# Checklist:

- [X] My code follows the [PEP 8](https://www.python.org/dev/peps/pep-0008/)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
