### PR TITLE
refactor: update error message if steps filter results are empty

### DIFF
--- a/tests/test_run_steps_filter.py
+++ b/tests/test_run_steps_filter.py
@@ -79,8 +79,8 @@ def check_filter_no_match(tmpdir, capsys, cli_params):
     exclude_pattern = "qwer"
     cli_params.extend(["-f", f"{include_pattern}:!{exclude_pattern}"])
     captured = check_empty_config_error(tmpdir, capsys, cli_params)
-    assert f"Include patterns: ['{include_pattern}']" in captured.out
-    assert f"Exclude patterns: ['{exclude_pattern}']" in captured.out
+    assert include_pattern in captured.out
+    assert exclude_pattern in captured.out
 
 
 def check_empty_config_error(tmpdir, capsys, cli_params):

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -389,7 +389,10 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
             raise CriticalCiException(text) from e
 
         if not self.project_config:
-            raise CriticalCiException("Project configs are empty, abort")
+            text = "Project configs are empty, abort"
+            if self.include_patterns or self.exclude_patterns:
+                text += f"\nRecheck filters applied:\n\tInclude patterns: {self.include_patterns}\n\tExclude patterns: {self.exclude_patterns}"
+            raise CriticalCiException(text)
 
         return self.project_config
 

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -391,7 +391,9 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
         if not self.project_config:
             text = "Project configs are empty, abort"
             if self.include_patterns or self.exclude_patterns:
-                text += f"\nRecheck filters applied:\n\tInclude patterns: {self.include_patterns}\n\tExclude patterns: {self.exclude_patterns}"
+                text += "\nRecheck filters applied:\n" + \
+                        f"\tInclude patterns: {self.include_patterns}\n" + \
+                        f"\tExclude patterns: {self.exclude_patterns}"
             raise CriticalCiException(text)
 
         return self.project_config


### PR DESCRIPTION
CLI parameters: `... -f 'asdf:!qwer'`
Error message if project config doesn't contain such steps:
```
2. Processing project configs
 |   ==> Adding file .../artifacts/CONFIGS_DUMP.txt to artifacts...
 |   Error: Project configs are empty, abort
 |   Recheck filters applied:
 |   	Include patterns: ['asdf']
 |   	Exclude patterns: ['qwer']
 └ [Failed]
```
