### PR TITLE
feat(structure_handler): initialize conditional steps logic

### DIFF
--- a/tests/test_conditional_steps.py
+++ b/tests/test_conditional_steps.py
@@ -28,8 +28,7 @@ def build_config_file(tmpdir, conditional_step_passed):
     config = inspect.cleandoc(f'''
         from universum.configuration_support import Configuration, Step
 
-        true_branch_step = Step(name='{true_branch_step_name}', command=['touch', '{true_branch_step_name}'],
-                                artifacts='{true_branch_step_name}')
+        true_branch_step = Step(name='{true_branch_step_name}', command=['touch', '{true_branch_step_name}'])
         false_branch_step = Step(name='{false_branch_step_name}', command=['touch', '{false_branch_step_name}'])
         conditional_step = Configuration([dict(name='conditional',
             command=['bash', '-c', 'exit {conditional_step_exit_code}'],
@@ -45,8 +44,10 @@ def build_config_file(tmpdir, conditional_step_passed):
 
 
 def check_conditional_step(tmpdir, capsys, config_file, conditional_step_passed):
+    artifacts_dir = tmpdir.join("artifacts")
     params = ["-vt", "none",
               "-fsd", str(tmpdir),
+              "-ad", str(artifacts_dir),
               "--clean-build",
               "-o", "console"]
     params.extend(["-cfg", str(config_file)])

--- a/tests/test_conditional_steps.py
+++ b/tests/test_conditional_steps.py
@@ -1,0 +1,58 @@
+import pytest
+import re
+
+from universum import __main__
+
+
+true_branch_step_name = "true branch"
+false_branch_step_name = "false branch"
+
+
+def test_conditional_true_branch(tmpdir, capsys):
+    check_conditional_step_success(tmpdir, capsys, conditional_step_passed=True)
+
+
+def test_conditional_false_branch(tmpdir, capsys):
+    check_conditional_step_success(tmpdir, capsys, conditional_step_passed=False)
+
+
+def check_conditional_step_success(tmpdir, capsys, conditional_step_passed):
+    config_file = build_config_file(tmpdir, conditional_step_passed)
+    check_conditional_step(tmpdir, capsys, config_file, conditional_step_passed)
+
+
+def build_config_file(tmpdir, conditional_step_passed):
+    conditional_step_exit_code = 0 if conditional_step_passed else 1
+    config = "from universum.configuration_support import Configuration, Step\n"
+    config += f"true_branch_step = Step(name='{true_branch_step_name}', command=['pwd'])\n"
+    config += f"false_branch_step = Step(name='{false_branch_step_name}', command=['ls'])\n"
+    config += "conditional_step = Configuration([{'name': 'conditional',\n"
+    config += f"   'command': ['bash', '-c', 'exit {conditional_step_exit_code}'],\n"
+    config += "    'if_succeeded': true_branch_step, 'if_failed': false_branch_step}])\n"
+    config += "configs = conditional_step"
+
+    config_file = tmpdir.join("configs.py")
+    config_file.write_text(config, "utf-8")
+
+    return config_file
+
+
+def check_conditional_step(tmpdir, capsys, config_file, conditional_step_passed):
+    params = ["-vt", "none",
+              "-fsd", str(tmpdir),
+              "--clean-build",
+              "-o", "console"]
+    params.extend(["-cfg", str(config_file)])
+
+    return_code = __main__.main(params)
+    assert return_code == 0
+
+    captured = capsys.readouterr()
+    conditional_step_succeeded_regexp = r"conditional.*Success.*\|   5\.2"
+    assert re.search(conditional_step_succeeded_regexp, captured.out, re.DOTALL)
+
+    expected_log = true_branch_step_name if conditional_step_passed else false_branch_step_name
+    unexpected_log = false_branch_step_name if conditional_step_passed else true_branch_step_name
+    assert expected_log in captured.out
+    assert not unexpected_log in captured
+

--- a/tests/test_conditional_steps.py
+++ b/tests/test_conditional_steps.py
@@ -1,5 +1,5 @@
-import pytest
 import re
+import pytest
 
 from universum import __main__
 
@@ -48,11 +48,10 @@ def check_conditional_step(tmpdir, capsys, config_file, conditional_step_passed)
     assert return_code == 0
 
     captured = capsys.readouterr()
-    conditional_step_succeeded_regexp = r"conditional.*Success.*\|   5\.2"
-    assert re.search(conditional_step_succeeded_regexp, captured.out, re.DOTALL)
+    conditional_succeeded_regexp = r"conditional.*Success.*\|   5\.2"
+    assert re.search(conditional_succeeded_regexp, captured.out, re.DOTALL)
 
     expected_log = true_branch_step_name if conditional_step_passed else false_branch_step_name
     unexpected_log = false_branch_step_name if conditional_step_passed else true_branch_step_name
     assert expected_log in captured.out
     assert not unexpected_log in captured
-

--- a/tests/test_conditional_steps.py
+++ b/tests/test_conditional_steps.py
@@ -57,7 +57,7 @@ def check_conditional_step(tmpdir, capsys, config_file, conditional_step_passed)
 
     captured = capsys.readouterr()
     print(captured.out)
-    conditional_succeeded_regexp = r"conditional.*Success.*\|   5\.2"
+    conditional_succeeded_regexp = r"\] conditional.*Success.*\|   5\.2"
     assert re.search(conditional_succeeded_regexp, captured.out, re.DOTALL)
 
     expected_log = true_branch_step_name if conditional_step_passed else false_branch_step_name

--- a/tests/test_conditional_steps.py
+++ b/tests/test_conditional_steps.py
@@ -1,6 +1,6 @@
 import re
-import pytest
 import inspect
+import pytest
 
 from universum import __main__
 

--- a/universum/configuration_support.py
+++ b/universum/configuration_support.py
@@ -184,6 +184,7 @@ class Step:
         self.if_env_set: str = if_env_set
         self.if_succeeded = if_succeeded
         self.if_failed = if_failed
+        self.is_conditional = self.if_succeeded or self.if_failed
         self.children: Optional['Configuration'] = None
         self._extras: Dict[str, str] = {}
         for key, value in kwargs.items():

--- a/universum/configuration_support.py
+++ b/universum/configuration_support.py
@@ -165,6 +165,8 @@ class Step:
                  pass_tag: str = '',
                  fail_tag: str = '',
                  if_env_set: str = '',
+                 if_succeeded = None,
+                 if_failed = None,
                  **kwargs) -> None:
         self.name: str = name
         self.directory: str = directory
@@ -180,6 +182,8 @@ class Step:
         self.pass_tag: str = pass_tag
         self.fail_tag: str = fail_tag
         self.if_env_set: str = if_env_set
+        self.if_succeeded = if_succeeded
+        self.if_failed = if_failed
         self.children: Optional['Configuration'] = None
         self._extras: Dict[str, str] = {}
         for key, value in kwargs.items():
@@ -383,6 +387,9 @@ class Step:
             pass_tag=self.pass_tag + other.pass_tag,
             fail_tag=self.fail_tag + other.fail_tag,
             if_env_set=self.if_env_set + other.if_env_set,
+            # FIXME: This is a dummy implementation. Define addition logic and implement it.
+            if_succeeded=other.if_succeeded,
+            if_failed=other.if_failed,
             **combine(self._extras, other._extras)
         )
 

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -275,8 +275,9 @@ class RunningStep:
                 text = utils.trim_and_convert_to_unicode(text)
                 if self.file:
                     self.file.write(text + "\n")
-                self.fail_block(text)
-                self.add_tag(self.configuration.fail_tag)
+                if not self.configuration.is_conditional:
+                    self.fail_block(text)
+                    self.add_tag(self.configuration.fail_tag)
                 raise StepException()
 
             self.add_tag(self.configuration.pass_tag)

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -221,6 +221,7 @@ class StructureHandler(HasOutput):
                 self.execute_conditional_branch_step(step.if_succeeded, step_executor)
         except StepException:
             if step.if_failed:
+                self.get_current_block().status = "Success"  # conditional step status should be always success
                 self.close_block()
                 self.execute_conditional_branch_step(step.if_failed, step_executor)
 

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -122,7 +122,7 @@ class StructureHandler(HasOutput):
             args_copy = list(args)
             if step:  # not all `run_in_block()` calls have a step parameter, but it's required for conditional steps logic
                 args_copy.insert(0, step)
-            result = operation(*args_copy, **kwargs);
+            result = operation(*args_copy, **kwargs)
         except (SilentAbortException, StepException):  # user-defined step failed
             if hasattr(step, "if_failed") and step.if_failed:
                 self.get_current_block().status = "Success"  # conditional step status should be always success
@@ -194,11 +194,13 @@ class StructureHandler(HasOutput):
                                           item, step_executor, obj_a.critical)
                         if obj_a.if_succeeded:
                             step_name = self._build_next_step_name(obj_a.if_succeeded.name)
-                            self.run_in_block(self.execute_one_step, step_name, False, obj_a.if_succeeded, step_executor, obj_a.critical)
+                            self.run_in_block(self.execute_one_step, step_name, False,
+                                              obj_a.if_succeeded, step_executor, obj_a.critical)
                     except (SilentAbortException, StepException):  # user-defined step failed
                         if obj_a.if_failed:
                             step_name = self._build_next_step_name(obj_a.if_failed.name)
-                            self.run_in_block(self.execute_one_step, step_name, False, obj_a.if_failed, step_executor, obj_a.critical)
+                            self.run_in_block(self.execute_one_step, step_name, False,
+                                              obj_a.if_failed, step_executor, obj_a.critical)
 
                 else:
                     step_name = self._build_next_step_name(item.name)

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -229,7 +229,7 @@ class StructureHandler(HasOutput):
         self.configs_current_number += 1
         step_name = self._build_step_name(step.name)
         self.open_block(step_name)
-        self.execute_one_step(step, step_executor, step.critical);
+        self.execute_one_step(step, step_executor, step.critical)
 
 
     def report_background_steps(self) -> bool:


### PR DESCRIPTION
Initial change for the conditional steps logic, the only basic scenario is implemented and tested. See a newly added test file for a usage example.

Additional logic to handle in the following PRs (which I'm aware of):
- steps addition and multiplying
- steps filtering
- the "critical" flag
- the "if_env_set" flag
- background execution

Please update this list with any ideas to check/implement.