### PR TITLE
chore: fix pylint 'invalid-name' issues

### DIFF
--- a/universum/configuration_support.py
+++ b/universum/configuration_support.py
@@ -436,7 +436,7 @@ class Step:
         return result
 
 
-DictType = TypeVar('DictType', bound=dict)
+DictType = TypeVar('DictTypeT', bound=dict)
 
 
 def combine(dictionary_a: DictType, dictionary_b: DictType) -> DictType:

--- a/universum/configuration_support.py
+++ b/universum/configuration_support.py
@@ -436,10 +436,10 @@ class Step:
         return result
 
 
-DictType = TypeVar('DictTypeT', bound=dict)
+DictTypeT = TypeVar('DictTypeT', bound=dict)
 
 
-def combine(dictionary_a: DictType, dictionary_b: DictType) -> DictType:
+def combine(dictionary_a: DictTypeT, dictionary_b: DictTypeT) -> DictTypeT:
     # TODO: move to utils, as this is no longer specific to configurations
     """
     Combine two dictionaries using plus operator for matching keys

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -70,10 +70,10 @@ class Module:
         return instance
 
 
-ComponentType = TypeVar('ComponentTypeT', bound=Module)
+ComponentTypeT = TypeVar('ComponentTypeT', bound=Module)
 
 
-def construct_component(cls: Type[ComponentType], main_settings: 'HasModulesMapping', *args, **kwargs) -> ComponentType:
+def construct_component(cls: Type[ComponentTypeT], main_settings: 'HasModulesMapping', *args, **kwargs) -> ComponentTypeT:
     if not getattr(main_settings, "active_modules", None):
         main_settings.active_modules = {}
 
@@ -86,21 +86,21 @@ def construct_component(cls: Type[ComponentType], main_settings: 'HasModulesMapp
         # noinspection PyArgumentList
         instance.__init__(*args, **kwargs)  # type: ignore
         main_settings.active_modules[cls] = instance
-    return cast(ComponentType, main_settings.active_modules[cls])
+    return cast(ComponentTypeT, main_settings.active_modules[cls])
 
 
-DependencyType = TypeVar('DependencyTypeT', bound=Module)
+DependencyTypeT = TypeVar('DependencyTypeT', bound=Module)
 
 
-class Dependency(Generic[DependencyType]):
-    def __init__(self, cls: Type[DependencyType]) -> None:
+class Dependency(Generic[DependencyTypeT]):
+    def __init__(self, cls: Type[DependencyTypeT]) -> None:
         self.cls = cls
 
     # The source and the target of the dependency are different modules,
     # so we need to use different type variables to annotate them.
     # instance parameter of the __get__ method is source module.
-    def __get__(self, instance: Module, owner: Any) -> Callable[..., DependencyType]:
-        def constructor_function(*args, **kwargs) -> DependencyType:
+    def __get__(self, instance: Module, owner: Any) -> Callable[..., DependencyTypeT]:
+        def constructor_function(*args, **kwargs) -> DependencyTypeT:
             return construct_component(self.cls, instance.main_settings, *args, **kwargs)
         return constructor_function
 

--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -70,7 +70,7 @@ class Module:
         return instance
 
 
-ComponentType = TypeVar('ComponentType', bound=Module)
+ComponentType = TypeVar('ComponentTypeT', bound=Module)
 
 
 def construct_component(cls: Type[ComponentType], main_settings: 'HasModulesMapping', *args, **kwargs) -> ComponentType:
@@ -89,7 +89,7 @@ def construct_component(cls: Type[ComponentType], main_settings: 'HasModulesMapp
     return cast(ComponentType, main_settings.active_modules[cls])
 
 
-DependencyType = TypeVar('DependencyType', bound=Module)
+DependencyType = TypeVar('DependencyTypeT', bound=Module)
 
 
 class Dependency(Generic[DependencyType]):


### PR DESCRIPTION
Issue:
```
[
    {
        "symbol": "invalid-name",
        "message": "Type variable name \"DictType\" doesn't conform to predefined naming style",
        "path": "universum/configuration_support.py",
        "line": 439
    },
    {
        "symbol": "invalid-name",
        "message": "Type variable name \"ComponentType\" doesn't conform to predefined naming style",
        "path": "universum/lib/gravity.py",
        "line": 73
    },
    {
        "symbol": "invalid-name",
        "message": "Type variable name \"DependencyType\" doesn't conform to predefined naming style",
        "path": "universum/lib/gravity.py",
        "line": 92
    }
][]
```