### PR TITLE
fix(Output): use default HTML log name if '-hl' CLI parameter was last

### DIFF
--- a/tests/test_html_output.py
+++ b/tests/test_html_output.py
@@ -74,6 +74,14 @@ def test_cli_log_custom_name(tmpdir):
 
 def test_cli_log_default_name(tmpdir):
     artifact_dir = check_cli(tmpdir, ["-hl"])
+    assert not os.path.exists(os.path.join(artifact_dir, "default"))
+    assert os.path.exists(os.path.join(artifact_dir, "universum_log.html"))
+
+
+# https://github.com/Samsung/Universum/issues/711
+def test_cli_log_default_name_last_parameter(tmpdir):
+    artifact_dir = check_cli(tmpdir, ["-hl"], is_html_last_param=True)
+    assert not os.path.exists(os.path.join(artifact_dir, "default"))
     assert os.path.exists(os.path.join(artifact_dir, "universum_log.html"))
 
 
@@ -299,7 +307,7 @@ def check_timestamps(body_element, universum_log_element):
     assert delta.seconds <= 60
 
 
-def check_cli(tmpdir, html_log_params):
+def check_cli(tmpdir, html_log_params, is_html_last_param=False):
     artifact_dir = tmpdir.join("artifacts")
     config_file = tmpdir.join("configs.py")
     config_file.write_text(config, "utf-8")
@@ -308,8 +316,14 @@ def check_cli(tmpdir, html_log_params):
                   "-fsd", str(tmpdir),
                   "-cfg", str(config_file),
                   "-ad", str(artifact_dir)]
-    html_log_params.extend(cli_params)
-    result = __main__.main(html_log_params)
+    if is_html_last_param:
+        cli_params.extend(html_log_params)
+        params = cli_params
+    else:
+        html_log_params.extend(cli_params)
+        params = html_log_params
+
+    result = __main__.main(params)
 
     assert result == 0
     return artifact_dir

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -31,8 +31,9 @@ class Output(Module):
                             help="Type of output to produce (tc - TeamCity, jenkins - Jenkins, term - terminal, "
                                  "github - Github Actions). TeamCity, Jenkins and Github Actions environments are "
                                  "detected automatically when launched on build agent.")
-        # `universum` -> html_log == default
-        # `universum -hl` -> html_log == const
+        # `universum` -> html_log == `default`
+        # `universum -hl ${other_params}` -> html_log == `const`
+        # `universum ${other_params} -hl` -> html_log == "default"
         # `universum -hl custom` -> html_log == custom
         parser.add_argument("--html-log", "-hl", nargs="?", const=HtmlOutput.default_name, default=None,
                             help=f"Generate a self-contained user-friendly HTML log. "
@@ -104,7 +105,8 @@ class Output(Module):
 
     def _create_html_driver(self):
         is_enabled = self.settings.html_log is not None
-        html_driver = self.html_driver_factory(log_name=self.settings.html_log) if is_enabled else None
+        log_name = HtmlOutput.default_name if self.settings.html_log == "default" else self.settings.html_log
+        html_driver = self.html_driver_factory(log_name=log_name) if is_enabled else None
         handler = HtmlDriverHandler(html_driver)
         return handler
 


### PR DESCRIPTION
The argument parser works differently depending on a CLI parameter position.
`universum -hl ${other_params}` -> `settings.html_log == "universum_log.html"`
`universum ${other_params} -hl` -> `settings.html_log == "default"`

Fix this to have a proper HTML log name regardless of CLI parameter position.
Resolves #711 