### PR TITLE
fix(pylint): warnings found by new pylint version

### DIFF
--- a/universum/lib/gravity.py
+++ b/universum/lib/gravity.py
@@ -73,17 +73,24 @@ class Module:
 ComponentTypeT = TypeVar('ComponentTypeT', bound=Module)
 
 
-def construct_component(cls: Type[ComponentTypeT], main_settings: 'HasModulesMapping', *args, **kwargs) -> ComponentTypeT:
+def construct_component(cls: Type[ComponentTypeT], main_settings: 'HasModulesMapping',
+                        *args, **kwargs) -> ComponentTypeT:
+
     if not getattr(main_settings, "active_modules", None):
         main_settings.active_modules = {}
 
     if cls not in main_settings.active_modules:
         cls.settings = Settings(cls)
+
+        # The module instance is constructed manually, because we need to set
+        # settings attribute before constructor is called
         instance: 'Module' = cls.__new__(cls, main_settings=main_settings)
+
         # https://github.com/python/mypy/blob/master/mypy/checkmember.py#180
         # Accessing __init__ in statically typed code would compromise
         # type safety unless used via super().
         # noinspection PyArgumentList
+        # pylint: disable = unnecessary-dunder-call
         instance.__init__(*args, **kwargs)  # type: ignore
         main_settings.active_modules[cls] = instance
     return cast(ComponentTypeT, main_settings.active_modules[cls])

--- a/universum/modules/automation_server/base_server.py
+++ b/universum/modules/automation_server/base_server.py
@@ -12,7 +12,7 @@ class BaseServerForTrigger(Module):
     Abstract base class for API of triggering builds on automation (CI) server
     """
 
-    def trigger_build(self, revision: str) -> None:  # pylint: disable=no-self-use
+    def trigger_build(self, revision: str) -> None:
         raise RuntimeError("Trigger build function is not defined for current driver.")
 
 
@@ -21,7 +21,7 @@ class BaseServerForHostingBuild(Module):
     Abstract base class for API of hosting CI builds on automation server
     """
 
-    def add_build_tag(self, tag: str) -> Response:  # pylint: disable=no-self-use
+    def add_build_tag(self, tag: str) -> Response:
         raise RuntimeError("Tag adding function is not defined for current driver.")
 
     def report_build_location(self) -> str:

--- a/universum/modules/vcs/base_vcs.py
+++ b/universum/modules/vcs/base_vcs.py
@@ -50,7 +50,7 @@ class BaseDownloadVcs(BaseVcs, HasErrorState):
     Base class for default CI build VCS drivers
     """
 
-    def code_review(self):  # pylint: disable=no-self-use
+    def code_review(self):
         return None
 
     def login(self):

--- a/universum/modules/vcs/github_vcs.py
+++ b/universum/modules/vcs/github_vcs.py
@@ -199,7 +199,7 @@ class GithubMainVcs(ReportObserver, git_vcs.GitMainVcs, GithubTokenWithInstallat
     def get_review_link(self):
         return self.settings.repo.rsplit(".git", 1)[0] + "/runs/" + self.settings.check_id
 
-    def is_latest_version(self):  # pylint: disable=no-self-use
+    def is_latest_version(self):
         return True
 
     def _report(self):

--- a/universum/modules/vcs/local_vcs.py
+++ b/universum/modules/vcs/local_vcs.py
@@ -38,7 +38,7 @@ class LocalMainVcs(base_vcs.BaseDownloadVcs, HasOutput, HasStructure, HasErrorSt
         else:
             self.source_dir = utils.parse_path(self.settings.source_dir, os.getcwd())
 
-    def calculate_file_diff(self):  # pylint: disable=no-self-use
+    def calculate_file_diff(self):
         return {}                   # No file diff can be calculated for local VCS
 
     @make_block("Copying sources to working directory")


### PR DESCRIPTION
Surprisingly, new pylint version complains about disable markers because
the corresponding check became disabled by default.