### PR TITLE
refactor(launcher): add RunningStep interface

### DIFF
--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -16,7 +16,7 @@ from ..lib.utils import make_block
 from . import automation_server, api_support, artifact_collector, reporter, code_report_collector
 from .output import HasOutput, Output
 from .project_directory import ProjectDirectory
-from .structure_handler import HasStructure
+from .structure_handler import HasStructure, RunningStepBase
 
 __all__ = [
     "Launcher",
@@ -158,19 +158,6 @@ def get_match_patterns(filters: Union[str, List[str]]) -> Tuple[List[str], List[
         elif f:
             include.append(f)
     return include, exclude
-
-
-class RunningStepBase(ABC):
-
-    error: Optional[str] = None
-
-    @abstractmethod
-    def start(self) -> None:
-        pass
-
-    @abstractmethod
-    def finalize(self):
-        pass
 
 
 class RunningStep(RunningStepBase):

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -5,7 +5,6 @@ from inspect import cleandoc
 from typing import Callable, Dict, List, Optional, TextIO, Tuple, Union
 from requests import Response
 import sh
-from abc import ABC, abstractmethod
 
 from .error_state import HasErrorState
 from .. import configuration_support

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import copy
+from abc import ABC, abstractmethod
 
 from typing import Callable, ClassVar, List, Optional, TypeVar, Union, Generator
 from typing_extensions import TypedDict
@@ -68,6 +69,19 @@ class BackgroundStepInfo(TypedDict):
     block: Block
     process: RunningStepBase
     is_critical: bool
+
+
+class RunningStepBase(ABC):
+
+    error: Optional[str] = None
+
+    @abstractmethod
+    def start(self) -> None:
+        pass
+
+    @abstractmethod
+    def finalize(self):
+        pass
 
 
 class StructureHandler(HasOutput):

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -159,7 +159,7 @@ class StructureHandler(HasOutput):
         process = background_step['process']
         process.finalize()
         if process.error is not None:
-            self.fail_block(background_step['block'], error)
+            self.fail_block(background_step['block'], process.error)
             self.fail_current_block()
             return False
 

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import copy
-from abc import ABC, abstractmethod
 
+from abc import ABC, abstractmethod
 from typing import Callable, ClassVar, List, Optional, TypeVar, Union, Generator
 from typing_extensions import TypedDict
 from ..configuration_support import Step, Configuration

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -152,9 +152,8 @@ class StructureHandler(HasOutput):
             self.close_block()
 
     def execute_one_step(self, configuration: Step,
-                         step_executor: Callable) -> Optional[str]:
-        # step_executor is [[Step], Step], but referring to Step creates circular dependency
-        process = step_executor(configuration)
+                         step_executor: Callable[[Step], RunningStepBase]) -> Optional[str]:
+        process: RunningStepBase = step_executor(configuration)
 
         process.start()
         if process.get_error() is not None:
@@ -171,10 +170,10 @@ class StructureHandler(HasOutput):
                                              'is_critical': configuration.critical})
         return None
 
-    def finalize_background_step(self, background_step: BackgroundStepInfo):
-        process = background_step['process']
+    def finalize_background_step(self, background_step: BackgroundStepInfo) -> bool:
+        process: RunningStepBase = background_step['process']
         process.finalize()
-        error = process.get_error()
+        error: Optional[str] = process.get_error()
         if error is not None:
             self.fail_block(background_step['block'], error)
             self.fail_current_block()

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -174,8 +174,9 @@ class StructureHandler(HasOutput):
     def finalize_background_step(self, background_step: BackgroundStepInfo):
         process = background_step['process']
         process.finalize()
-        if process.get_error() is not None:
-            self.fail_block(background_step['block'], process.get_error())
+        error = process.get_error()
+        if error is not None:
+            self.fail_block(background_step['block'], error)
             self.fail_current_block()
             return False
 


### PR DESCRIPTION
Refactoring according to [this](https://github.com/Samsung/Universum/pull/718#discussion_r929894902) comment:

> Instead of returning tuple, I suggest to perform some refactoring:
> 
>     1. Declare interface for running step explicitly, as an abstract base class
> 
>     2. Use type declaration of this interface for type checking with mypy
> 
>     3. Include error status into this interface instead of returning it from the "start" and "finalize" functions separately
> 
>     4. Pass the object into active_background_steps instead of passing separate methods
