### PR TITLE
fix(analyzer): wrong error on missing input file

### DIFF
--- a/universum/analyzers/utils.py
+++ b/universum/analyzers/utils.py
@@ -110,7 +110,15 @@ def expand_files_argument(settings: argparse.Namespace) -> None:
     # TODO: subclass argparse.Action
     result = []
     for pattern in settings.file_list:
-        result.extend(glob.glob(pattern))
+        file_list: List[str] = glob.glob(pattern)
+        if not file_list:
+            sys.stderr.write(f"Warning: no files found for input pattern {pattern}\n")
+        else:
+            result.extend(file_list)
+
+    if not result:
+        raise AnalyzerException(message="Error: no files found for analysis")
+
     settings.file_list = result
 
 

--- a/universum/analyzers/utils.py
+++ b/universum/analyzers/utils.py
@@ -5,7 +5,7 @@ import glob
 import pathlib
 import subprocess
 
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple, Set
 from typing_extensions import TypedDict
 
 from universum.lib.ci_exception import CiException
@@ -108,7 +108,7 @@ def add_files_argument(parser: argparse.ArgumentParser) -> None:
 
 def expand_files_argument(settings: argparse.Namespace) -> None:
     # TODO: subclass argparse.Action
-    result: set[str] = set()
+    result: Set[str] = set()
     for pattern in settings.file_list:
         file_list: List[str] = glob.glob(pattern)
         if not file_list:

--- a/universum/analyzers/utils.py
+++ b/universum/analyzers/utils.py
@@ -108,18 +108,18 @@ def add_files_argument(parser: argparse.ArgumentParser) -> None:
 
 def expand_files_argument(settings: argparse.Namespace) -> None:
     # TODO: subclass argparse.Action
-    result = []
+    result: set[str] = set()
     for pattern in settings.file_list:
         file_list: List[str] = glob.glob(pattern)
         if not file_list:
             sys.stderr.write(f"Warning: no files found for input pattern {pattern}\n")
         else:
-            result.extend(file_list)
+            result.update(file_list)
 
     if not result:
-        raise AnalyzerException(message="Error: no files found for analysis")
+        raise AnalyzerException(message="Error: no files found for analysis\n")
 
-    settings.file_list = result
+    settings.file_list = list(result)
 
 
 def add_result_file_argument(parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
When the passed input file is missing, there were no explicit error
message. Instead, the empty list of files to analyze was passed to the
actual analysis tool. As the result, the error message was incorrect and
hard to understand. Fixed by producing warning on each missing input
file and producing error if the final list is empty.
