### PR TITLE
refactor(output): rename and reorder methods

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,7 @@ Project 'Universum'
     code_report.rst
     github_handler.rst
     universum_docs.rst
+    internal.rst
     teamcity.rst
     jenkins.rst
     examples.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,10 +13,10 @@ Project 'Universum'
     code_report.rst
     github_handler.rst
     universum_docs.rst
-    internal.rst
     teamcity.rst
     jenkins.rst
     examples.rst
+    internal.rst
     changelog_ref.rst
 
 .. image:: _static/logo.svg

--- a/doc/internal.rst
+++ b/doc/internal.rst
@@ -1,0 +1,9 @@
+Internal documentation
+----------------------
+
+.. automodule:: universum.modules.output.base_output
+    :members:
+    :special-members:
+
+    :mod:`universum.modules.output.base_output`
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ class FuzzyCallChecker:
 
 @pytest.fixture()
 def stdout_checker(request):
-    with mock.patch('universum.modules.output.terminal_based_output.TerminalBasedOutput.stdout') as logging_mock:
+    with mock.patch('universum.modules.output.terminal_based_output.TerminalBasedOutput._stdout') as logging_mock:
         result = FuzzyCallChecker(logging_mock)
         yield result
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def stdout_checker(request):
 
 @pytest.fixture()
 def log_exception_checker(request):
-    with mock.patch('universum.modules.output.terminal_based_output.TerminalBasedOutput.log_exception') as logging_mock:
+    with mock.patch('universum.modules.output.terminal_based_output.TerminalBasedOutput.log_error') as logging_mock:
         result = FuzzyCallChecker(logging_mock)
         yield result
 

--- a/universum/__main__.py
+++ b/universum/__main__.py
@@ -60,7 +60,7 @@ def run(settings: ModuleNamespace) -> int:
     signal.signal(signal.SIGTERM, signal_handler)
 
     try:
-        with Uninterruptible(main_module.out.log_exception) as run_function:
+        with Uninterruptible(main_module.out.log_error) as run_function:
             run_function(main_module.execute)
             run_function(main_module.finalize)
 
@@ -69,7 +69,7 @@ def run(settings: ModuleNamespace) -> int:
 
     except Exception as e:
         ex_traceback = sys.exc_info()[2]
-        main_module.out.log_exception("Unexpected error.\n" + format_traceback(e, ex_traceback))
+        main_module.out.log_error("Unexpected error.\n" + format_traceback(e, ex_traceback))
         main_module.out.report_build_problem("Unexpected error while executing script.")
         result = 2
 

--- a/universum/__main__.py
+++ b/universum/__main__.py
@@ -1,11 +1,11 @@
-from typing import List, Optional
 import signal
 import sys
+from typing import List, Optional
 
 from . import __version__, __title__
 from .api import Api
-from .github_handler import GithubHandler
 from .config_creator import ConfigCreator
+from .github_handler import GithubHandler
 from .lib.ci_exception import SilentAbortException
 from .lib.gravity import define_arguments_recursive, construct_component
 from .lib.module_arguments import ModuleArgumentParser, ModuleNamespace, IncorrectParameterError
@@ -50,7 +50,7 @@ def run(settings: ModuleNamespace) -> int:
     main_module = construct_component(settings.main_class, settings)
 
     if error_state_module.is_in_error_state():
-        raise IncorrectParameterError(("\n\n"+"-"*80 + "\n").join(error_state_module.get_errors()))
+        raise IncorrectParameterError(("\n\n" + "-" * 80 + "\n").join(error_state_module.get_errors()))
 
     main_module.out.log_execution_start(__title__, __version__)
 
@@ -87,8 +87,8 @@ def main(args: Optional[List[str]] = None) -> int:
         return run(settings)
     except IncorrectParameterError as e:
         settings.command_parser.print_usage(sys.stderr)
-        sys.stderr.write("\nThe following errors were encountered:\n" + "-"*80+"\n")
-        sys.stderr.write(str(e)+"\n")
+        sys.stderr.write("\nThe following errors were encountered:\n" + "-" * 80 + "\n")
+        sys.stderr.write(str(e) + "\n")
         return 2
     except ImportError as e:
         print(e)

--- a/universum/main.py
+++ b/universum/main.py
@@ -1,12 +1,12 @@
 from typing import ClassVar
+
 from . import __title__
+from .configuration_support import Configuration
 from .lib.ci_exception import SilentAbortException
 from .lib.gravity import Dependency
 from .lib.module_arguments import ModuleArgumentParser
 from .modules import vcs, artifact_collector, reporter, launcher, code_report_collector
 from .modules.output import HasOutput
-from .configuration_support import Configuration
-
 
 __all__ = ["Main"]
 

--- a/universum/main.py
+++ b/universum/main.py
@@ -67,7 +67,7 @@ class Main(HasOutput):
         if self.settings.build_only_latest:
             if not self.vcs.is_latest_review_version():
                 self.out.log("Build skipped because review revision is not latest")
-                self.out.set_build_title("Skipped - review revision is not latest")
+                self.out.set_build_status("Skipped - review revision is not latest")
                 raise SilentAbortException(application_exit_code=0)
 
         self.vcs.prepare_repository()

--- a/universum/main.py
+++ b/universum/main.py
@@ -67,7 +67,7 @@ class Main(HasOutput):
         if self.settings.build_only_latest:
             if not self.vcs.is_latest_review_version():
                 self.out.log("Build skipped because review revision is not latest")
-                self.out.report_build_status("Skipped - review revision is not latest")
+                self.out.set_build_title("Skipped - review revision is not latest")
                 raise SilentAbortException(application_exit_code=0)
 
         self.vcs.prepare_repository()

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -5,14 +5,14 @@ import urllib.parse
 from copy import deepcopy
 from typing import Dict, List, Optional, TextIO, Tuple
 
-from ..configuration_support import Configuration
+from . import artifact_collector, reporter
 from .output import HasOutput
 from .project_directory import ProjectDirectory
-from . import artifact_collector, reporter
+from .structure_handler import HasStructure
+from ..configuration_support import Configuration
 from ..lib import utils
 from ..lib.gravity import Dependency
 from ..lib.utils import make_block
-from .structure_handler import HasStructure
 
 
 class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
@@ -95,7 +95,7 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
             json_file: TextIO = self.artifacts.create_text_file("Static_analysis_report.json")
             json_file.write(json.dumps(report, indent=4))
 
-            issue_count: int = 0
+            issue_count: int
             if report or report == []:
                 try:
                     issue_count = self._report_as_sarif_json(report)

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -103,15 +103,15 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
                     try:
                         issue_count = self._report_as_pylint_json(report)
                     except (KeyError, AttributeError, ValueError):
-                        self.out.log_stderr("Could not parse report file. Something went wrong.")
+                        self.out.log_exception("Could not parse report file. Something went wrong.")
                         continue
             else:
-                self.out.log_stderr("There are no results in code report file. Something went wrong.")
+                self.out.log_exception("There are no results in code report file. Something went wrong.")
                 continue
 
             if issue_count != 0:
                 text = str(issue_count) + " issues"
-                self.out.log_stderr("Found " + text)
+                self.out.log_exception("Found " + text)
                 self.out.report_build_status(os.path.splitext(os.path.basename(report_file))[0] + ": " + text)
             else:
                 self.out.log("Issues not found.")

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -103,15 +103,15 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
                     try:
                         issue_count = self._report_as_pylint_json(report)
                     except (KeyError, AttributeError, ValueError):
-                        self.out.log_exception("Could not parse report file. Something went wrong.")
+                        self.out.log_error("Could not parse report file. Something went wrong.")
                         continue
             else:
-                self.out.log_exception("There are no results in code report file. Something went wrong.")
+                self.out.log_error("There are no results in code report file. Something went wrong.")
                 continue
 
             if issue_count != 0:
                 text = str(issue_count) + " issues"
-                self.out.log_exception("Found " + text)
+                self.out.log_error("Found " + text)
                 self.out.report_build_status(os.path.splitext(os.path.basename(report_file))[0] + ": " + text)
             else:
                 self.out.log("Issues not found.")

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -112,6 +112,6 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
             if issue_count != 0:
                 text = str(issue_count) + " issues"
                 self.out.log_error("Found " + text)
-                self.out.report_build_status(os.path.splitext(os.path.basename(report_file))[0] + ": " + text)
+                self.out.set_build_title(os.path.splitext(os.path.basename(report_file))[0] + ": " + text)
             else:
                 self.out.log("Issues not found.")

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -96,22 +96,22 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
             json_file.write(json.dumps(report, indent=4))
 
             issue_count: int
-            if report or report == []:
-                try:
-                    issue_count = self._report_as_sarif_json(report)
-                except (KeyError, AttributeError, ValueError):
-                    try:
-                        issue_count = self._report_as_pylint_json(report)
-                    except (KeyError, AttributeError, ValueError):
-                        self.out.log_error("Could not parse report file. Something went wrong.")
-                        continue
-            else:
+            if not report and report != []:
                 self.out.log_error("There are no results in code report file. Something went wrong.")
                 continue
+
+            try:
+                issue_count = self._report_as_sarif_json(report)
+            except (KeyError, AttributeError, ValueError):
+                try:
+                    issue_count = self._report_as_pylint_json(report)
+                except (KeyError, AttributeError, ValueError):
+                    self.out.log_error("Could not parse report file. Something went wrong.")
+                    continue
 
             if issue_count != 0:
                 text = str(issue_count) + " issues"
                 self.out.log_error("Found " + text)
-                self.out.set_build_title(os.path.splitext(os.path.basename(report_file))[0] + ": " + text)
+                self.out.set_build_status(os.path.splitext(os.path.basename(report_file))[0] + ": " + text)
             else:
                 self.out.log("Issues not found.")

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -231,9 +231,9 @@ class RunningStep(RunningStepBase):
         if self.file:
             self.file.write(line + "\n")
         elif self._is_background:
-            self._postponed_out.append((self.out.log_shell_output, line))
+            self._postponed_out.append((self.out.log_stdout, line))
         else:
-            self.out.log_shell_output(line)
+            self.out.log_stdout(line)
 
     def handle_stderr(self, line: str) -> None:
         line = utils.trim_and_convert_to_unicode(line)
@@ -250,7 +250,7 @@ class RunningStep(RunningStepBase):
 
         request: Response = self.send_tag(tag)
         if request.status_code != 200:
-            self.out.log_stderr(request.text)
+            self.out.log_exception(request.text)
         else:
             self.out.log("Tag '" + tag + "' added to build.")
 

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -3,19 +3,20 @@ import re
 import sys
 from inspect import cleandoc
 from typing import Callable, Dict, List, Optional, TextIO, Tuple, Union
-from requests import Response
-import sh
 
+import sh
+from requests import Response
+
+from . import automation_server, api_support, artifact_collector, reporter, code_report_collector
 from .error_state import HasErrorState
+from .output import HasOutput, Output
+from .project_directory import ProjectDirectory
+from .structure_handler import HasStructure, RunningStepBase
 from .. import configuration_support
 from ..lib import utils
 from ..lib.ci_exception import CiException, CriticalCiException
 from ..lib.gravity import Dependency
 from ..lib.utils import make_block
-from . import automation_server, api_support, artifact_collector, reporter, code_report_collector
-from .output import HasOutput, Output
-from .project_directory import ProjectDirectory
-from .structure_handler import HasStructure, RunningStepBase
 
 __all__ = [
     "Launcher",
@@ -320,7 +321,7 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
                                                      "External command launching and reporting parameters")
 
         parser.add_argument("--config", "-cfg", dest="config_path", metavar="CONFIG_PATH",
-                            help="Path to project configuration file (example: -cfg=my/prject/my_conf.py). "
+                            help="Path to project configuration file (example: -cfg=my/project/my_conf.py). "
                                  "Default is ``.universum.py``")
 
         parser.add_argument("--filter", "-f", dest="step_filter", action='append', metavar="STEP_FILTER",
@@ -394,7 +395,7 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
             ex_traceback = sys.exc_info()[2]
             text = "Exception while processing Universum configuration file:\n" + \
                    utils.format_traceback(e, ex_traceback) + \
-                   "\nTry to execute ``confgs.dump()`` to make sure no exceptions occur in that case."
+                   "\nTry to execute ``configs.dump()`` to make sure no exceptions occur in that case."
             raise CriticalCiException(text) from e
 
         if not self.project_config:
@@ -418,7 +419,7 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
 
         additional_environment = self.api_support.get_environment_settings()
         return RunningStep(item, self.out, self.server.add_build_tag,
-                    log_file, working_directory, additional_environment, item.background)
+                           log_file, working_directory, additional_environment, item.background)
 
     def launch_custom_configs(self, custom_configs: configuration_support.Configuration) -> None:
         self.structure.execute_step_structure(custom_configs, self.create_process)

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -250,7 +250,7 @@ class RunningStep(RunningStepBase):
 
         request: Response = self.send_tag(tag)
         if request.status_code != 200:
-            self.out.log_exception(request.text)
+            self.out.log_error(request.text)
         else:
             self.out.log("Tag '" + tag + "' added to build.")
 

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -3,46 +3,130 @@ from ...lib.gravity import Module
 
 class BaseOutput(Module):
     """
-    Abstract base class for output drivers
+    Abstract base class for output drivers.  Defines methods that have to be implemented by each module that
+    implements a type of output.
     """
 
     def log_execution_start(self, title: str, version: str) -> None:
+        """
+        Print the universum startup message, for example:
+        "==> Universum xx.yy.zz started execution"
+
+        :param title: name of the product
+        :param version: version of the product
+        """
         self.log(self._build_execution_start_msg(title, version))
 
     def log_execution_finish(self, title: str, version: str) -> None:
+        """
+        Print the universum finished message, for example:
+        "==> Universum xx.yy.zz finished execution"
+
+        :param title: name of the product
+        :param version: version of the product
+        """
         self.log(self._build_execution_finish_msg(title, version))
 
     def log(self, line: str) -> None:
+        """
+        Print a line to the output. The most generic type of log.
+        Mostly used for printing own messages of universum.
+
+        :param line: the line to print
+        """
         raise NotImplementedError
 
     def log_error(self, description: str) -> None:
+        """
+        Print an error message to the output. Error may use different colors or other formatting.
+
+        :param description: the detailed error message
+        """
         raise NotImplementedError
 
     def log_external_command(self, command: str) -> None:
+        """
+        Print the start of the external command with parameters.
+
+        :param command: external command with parameters
+        """
         raise NotImplementedError
 
     def log_stdout(self, line: str) -> None:
+        """
+        Print one line of the standard output of the previously launched external command.
+
+        :param line: the line to print
+        """
         raise NotImplementedError
 
     def log_stderr(self, line: str) -> None:
+        """
+        Print one line of the standard error output of the previously launched external command.
+
+        :param line: the line to print
+        """
         raise NotImplementedError
 
     def open_block(self, num_str: str, name: str) -> None:
+        """
+        Start the block of the output. Block is a group of related output lines.
+
+        :param num_str: the string that represents the block number within the hierarchy.
+            Inner blocks are numbered using dot notation.
+            The number string is passed as a separate parameter to allow implementing different formatting for number and
+            name.
+        :param name: the title of the block.
+        """
         raise NotImplementedError
 
     def close_block(self, num_str: str, name: str, status: str) -> None:
+        """
+        End the block of the output.
+
+        :param num_str: the string that represents the block number
+        :param name: the title of the block
+        :param status: the completion status of the block: "Passed" or "Failed"
+        """
         raise NotImplementedError
 
     def log_skipped(self, message: str) -> None:
+        """
+        Print a message related to skipping steps. It could be a warning that further steps are skipped, or a message
+        that the step is skipped.
+
+        :param message: the message to print
+        """
         raise NotImplementedError
 
     def log_summary_step(self, step_title: str, has_children: bool, status: str) -> None:
+        """
+        Print a summary of the step execution at the end of the run.
+
+        :param step_title: the title of the step
+        :param has_children: whether the step has children or not. Typically, if step has children, the status is not
+            included in the summary.
+        :param status: the status of the step: "Passed", "Failed" or "Skipped"
+        """
         raise NotImplementedError
 
     def report_build_problem(self, description: str) -> None:
+        """
+        TeamCity only. Report run problem to the TeamCity via the output. Also fails the build regardless of the process
+        exit code. Multiple build problems for single run can be reported.
+
+        :param description: the description of the problem
+        """
         raise NotImplementedError
 
-    def set_build_title(self, message: str) -> None:
+    def set_build_title(self, title: str) -> None:
+        """
+        TeamCity only. Set the title of the build. Changes the title of the build visible in the configuration build
+        history and on the build page itself. For builds containing build problems, by default the title is
+        automatically populated with them by the TeamCity server itself. This method allows to override the title.
+
+        :param title: the title of the build
+        """
         raise NotImplementedError
 
     @staticmethod

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -18,8 +18,8 @@ class BaseOutput(Module):
     def report_skipped(self, message):
         raise NotImplementedError
 
-    def report_step(self, message, status):
-        self.log(message)
+    def report_step(self, step_title, has_children, status):
+        raise NotImplementedError
 
     def change_status(self, message):
         raise NotImplementedError

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -12,19 +12,19 @@ class BaseOutput(Module):
     def close_block(self, num_str, name, status):
         raise NotImplementedError
 
-    def report_error(self, description):
+    def log_skipped(self, message):
         raise NotImplementedError
 
-    def report_skipped(self, message):
+    def log_summary_step(self, step_title, has_children, status):
         raise NotImplementedError
 
-    def report_step(self, step_title, has_children, status):
+    def report_build_problem(self, description):
         raise NotImplementedError
 
-    def change_status(self, message):
+    def set_build_title(self, message):
         raise NotImplementedError
 
-    def log_error(self, msg):
+    def log_error(self, description):
         raise NotImplementedError
 
     def log_external_command(self, command):

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -6,49 +6,49 @@ class BaseOutput(Module):
     Abstract base class for output drivers
     """
 
-    def log_execution_start(self, title, version):
+    def log_execution_start(self, title: str, version: str) -> None:
         self.log(self._build_execution_start_msg(title, version))
 
-    def log_execution_finish(self, title, version):
+    def log_execution_finish(self, title: str, version: str) -> None:
         self.log(self._build_execution_finish_msg(title, version))
 
-    def log(self, line):
+    def log(self, line: str) -> None:
         raise NotImplementedError
 
-    def log_error(self, description):
+    def log_error(self, description: str) -> None:
         raise NotImplementedError
 
-    def log_external_command(self, command):
+    def log_external_command(self, command: str) -> None:
         raise NotImplementedError
 
-    def log_stdout(self, line):
+    def log_stdout(self, line: str) -> None:
         raise NotImplementedError
 
-    def log_stderr(self, line):
+    def log_stderr(self, line: str) -> None:
         raise NotImplementedError
 
-    def open_block(self, num_str, name):
+    def open_block(self, num_str: str, name: str) -> None:
         raise NotImplementedError
 
-    def close_block(self, num_str, name, status):
+    def close_block(self, num_str: str, name: str, status: str) -> None:
         raise NotImplementedError
 
-    def log_skipped(self, message):
+    def log_skipped(self, message: str) -> None:
         raise NotImplementedError
 
-    def log_summary_step(self, step_title, has_children, status):
+    def log_summary_step(self, step_title: str, has_children: bool, status: str) -> None:
         raise NotImplementedError
 
-    def report_build_problem(self, description):
+    def report_build_problem(self, description: str) -> None:
         raise NotImplementedError
 
-    def set_build_title(self, message):
+    def set_build_title(self, message: str) -> None:
         raise NotImplementedError
 
     @staticmethod
-    def _build_execution_start_msg(title, version):
+    def _build_execution_start_msg(title: str, version: str) -> str:
         return f"{title} {version} started execution"
 
     @staticmethod
-    def _build_execution_finish_msg(title, version):
+    def _build_execution_finish_msg(title: str, version: str) -> str:
         return f"{title} {version} finished execution"

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -6,6 +6,27 @@ class BaseOutput(Module):
     Abstract base class for output drivers
     """
 
+    def log_execution_start(self, title, version):
+        self.log(self._build_execution_start_msg(title, version))
+
+    def log_execution_finish(self, title, version):
+        self.log(self._build_execution_finish_msg(title, version))
+
+    def log(self, line):
+        raise NotImplementedError
+
+    def log_error(self, description):
+        raise NotImplementedError
+
+    def log_external_command(self, command):
+        raise NotImplementedError
+
+    def log_stdout(self, line):
+        raise NotImplementedError
+
+    def log_stderr(self, line):
+        raise NotImplementedError
+
     def open_block(self, num_str, name):
         raise NotImplementedError
 
@@ -23,27 +44,6 @@ class BaseOutput(Module):
 
     def set_build_title(self, message):
         raise NotImplementedError
-
-    def log_error(self, description):
-        raise NotImplementedError
-
-    def log_external_command(self, command):
-        raise NotImplementedError
-
-    def log_stdout(self, line):
-        raise NotImplementedError
-
-    def log_stderr(self, line):
-        raise NotImplementedError
-
-    def log(self, line):
-        raise NotImplementedError
-
-    def log_execution_start(self, title, version):
-        self.log(self._build_execution_start_msg(title, version))
-
-    def log_execution_finish(self, title, version):
-        self.log(self._build_execution_finish_msg(title, version))
 
     @staticmethod
     def _build_execution_start_msg(title, version):

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -27,6 +27,9 @@ class BaseOutput(Module):
     def log_exception(self, line):
         raise NotImplementedError
 
+    def log_stdout(self, line):
+        raise NotImplementedError
+
     def log_stderr(self, line):
         raise NotImplementedError
 
@@ -34,9 +37,6 @@ class BaseOutput(Module):
         raise NotImplementedError
 
     def log_external_command(self, command):
-        raise NotImplementedError
-
-    def log_shell_output(self, line):
         raise NotImplementedError
 
     def log_execution_start(self, title, version):

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -24,7 +24,10 @@ class BaseOutput(Module):
     def change_status(self, message):
         raise NotImplementedError
 
-    def log_exception(self, line):
+    def log_error(self, msg):
+        raise NotImplementedError
+
+    def log_external_command(self, command):
         raise NotImplementedError
 
     def log_stdout(self, line):
@@ -34,9 +37,6 @@ class BaseOutput(Module):
         raise NotImplementedError
 
     def log(self, line):
-        raise NotImplementedError
-
-    def log_external_command(self, command):
         raise NotImplementedError
 
     def log_execution_start(self, title, version):

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -71,6 +71,8 @@ class BaseOutput(Module):
     def open_block(self, num_str: str, name: str) -> None:
         """
         Start the block of the output. Block is a group of related output lines.
+        Depending on the capabilities of the output, the blocks can be marked by indentation, color or numbering.
+        Output can also implement dynamic blocks collapsing and expanding.
 
         :param num_str: the string that represents the block number within the hierarchy.
             Inner blocks are numbered using dot notation.

--- a/universum/modules/output/base_output.py
+++ b/universum/modules/output/base_output.py
@@ -39,6 +39,8 @@ class BaseOutput(Module):
     def log_error(self, description: str) -> None:
         """
         Print an error message to the output. Error may use different colors or other formatting.
+        Used for printing own error messages of the universum as well as error messages from other modules and libraries
+        and operating system.
 
         :param description: the detailed error message
         """
@@ -46,7 +48,8 @@ class BaseOutput(Module):
 
     def log_external_command(self, command: str) -> None:
         """
-        Print the start of the external command with parameters.
+        Print the start of the launch of the external command. Full command line with all arameters is supposed to be
+        printed.
 
         :param command: external command with parameters
         """
@@ -54,7 +57,8 @@ class BaseOutput(Module):
 
     def log_stdout(self, line: str) -> None:
         """
-        Print one line of the standard output of the previously launched external command.
+        Print one line of the standard output of the previously launched external command. The only usage is for
+        printing output of the commands that are launched during the execution of the universum config.
 
         :param line: the line to print
         """
@@ -62,7 +66,8 @@ class BaseOutput(Module):
 
     def log_stderr(self, line: str) -> None:
         """
-        Print one line of the standard error output of the previously launched external command.
+        Print one line of the standard error output of the previously launched external command. The only usage is for
+        printing standard error output of the commands that are launched during the execution of the universum config.
 
         :param line: the line to print
         """
@@ -121,13 +126,13 @@ class BaseOutput(Module):
         """
         raise NotImplementedError
 
-    def set_build_title(self, title: str) -> None:
+    def set_build_status(self, status: str) -> None:
         """
-        TeamCity only. Set the title of the build. Changes the title of the build visible in the configuration build
-        history and on the build page itself. For builds containing build problems, by default the title is
-        automatically populated with them by the TeamCity server itself. This method allows to override the title.
+        TeamCity only. Set the title of the build. Changes the status of the build visible in the configuration build
+        history and on the build page itself. For builds containing build problems, by default the status is
+        automatically populated with them by the TeamCity server itself. This method allows to override the status.
 
-        :param title: the title of the build
+        :param status: the status (title) of the build
         """
         raise NotImplementedError
 

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -7,7 +7,7 @@ __all__ = [
 
 class GithubOutput(TerminalBasedOutput):
     """
-    Github Actions manual: https://docs.github.com/en/actions
+    GitHub Actions manual: https://docs.github.com/en/actions
     GitHub doesn't support nested grouping (https://github.com/actions/runner/issues/802)
     """
 

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from .terminal_based_output import TerminalBasedOutput
 
 __all__ = [
@@ -18,7 +20,7 @@ class GithubOutput(TerminalBasedOutput):
     def _print_lines(self, *args, **kwargs):
         prefix: str = kwargs.setdefault("prefix", "")
         result: str = "".join(args)
-        lines: list[str] = result.splitlines(False)
+        lines: List[str] = result.splitlines(False)
         for line in lines:  # type: str
             self._stdout(f"{prefix}{line}")
 

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -15,33 +15,33 @@ class GithubOutput(TerminalBasedOutput):
         super().__init__(*args, **kwargs)
         self._block_opened = False
 
-    def print_lines(self, *args, **kwargs):
+    def _print_lines(self, *args, **kwargs):
         prefix = kwargs.setdefault("prefix", "")
         result = "".join(args)
         lines = result.splitlines(False)
         for line in lines:
-            self.stdout(f"{prefix}{line}")
+            self._stdout(f"{prefix}{line}")
+
+    def log_error(self, description):
+        self._print_lines(description, prefix="::error::")
+
+    def log_stderr(self, line):
+        self._print_lines("stderr: ", line, prefix="::warning::")
 
     def open_block(self, num_str, name):
         if self._block_opened:
-            self.print_lines("::endgroup::")
+            self._print_lines("::endgroup::")
 
-        self.print_lines(f"::group::{num_str} {name}")
+        self._print_lines(f"::group::{num_str} {name}")
         self._block_opened = True
 
     def close_block(self, num_str, name, status):
         if self._block_opened:
             self._block_opened = False
-            self.print_lines("::endgroup::")
+            self._print_lines("::endgroup::")
 
         if status == "Failed":
-            self.print_lines(f"::error::{num_str} {name} - Failed")
+            self._print_lines(f"::error::{num_str} {name} - Failed")
 
     def log_skipped(self, message):
-        self.print_lines(message, prefix="::warning::")
-
-    def log_error(self, description):
-        self.print_lines(description, prefix="::error::")
-
-    def log_stderr(self, line):
-        self.print_lines("stderr: ", line, prefix="::warning::")
+        self._print_lines(message, prefix="::warning::")

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -17,11 +17,11 @@ class GithubOutput(TerminalBasedOutput):
         super().__init__(*args, **kwargs)
         self._block_opened: bool = False
 
-    def _print_lines(self, *args, **kwargs):
+    def _print_lines(self, *args, **kwargs) -> None:
         prefix: str = kwargs.setdefault("prefix", "")
         result: str = "".join(args)
         lines: List[str] = result.splitlines(False)
-        for line in lines:  # type: str
+        for line in lines:
             self._stdout(f"{prefix}{line}")
 
     def log_error(self, description: str) -> None:

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -37,11 +37,11 @@ class GithubOutput(TerminalBasedOutput):
         if status == "Failed":
             self.print_lines(f"::error::{num_str} {name} - Failed")
 
-    def report_skipped(self, message):
+    def log_skipped(self, message):
         self.print_lines(message, prefix="::warning::")
 
-    def log_error(self, line):
-        self.print_lines(line, prefix="::error::")
+    def log_error(self, description):
+        self.print_lines(description, prefix="::error::")
 
     def log_stderr(self, line):
         self.print_lines("stderr: ", line, prefix="::warning::")

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -11,31 +11,31 @@ class GithubOutput(TerminalBasedOutput):
     GitHub doesn't support nested grouping (https://github.com/actions/runner/issues/802)
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._block_opened = False
+        self._block_opened: bool = False
 
     def _print_lines(self, *args, **kwargs):
-        prefix = kwargs.setdefault("prefix", "")
-        result = "".join(args)
-        lines = result.splitlines(False)
-        for line in lines:
+        prefix: str = kwargs.setdefault("prefix", "")
+        result: str = "".join(args)
+        lines: list[str] = result.splitlines(False)
+        for line in lines:  # type: str
             self._stdout(f"{prefix}{line}")
 
-    def log_error(self, description):
+    def log_error(self, description: str) -> None:
         self._print_lines(description, prefix="::error::")
 
-    def log_stderr(self, line):
+    def log_stderr(self, line: str) -> None:
         self._print_lines("stderr: ", line, prefix="::warning::")
 
-    def open_block(self, num_str, name):
+    def open_block(self, num_str: str, name: str) -> None:
         if self._block_opened:
             self._print_lines("::endgroup::")
 
         self._print_lines(f"::group::{num_str} {name}")
         self._block_opened = True
 
-    def close_block(self, num_str, name, status):
+    def close_block(self, num_str: str, name: str, status: str) -> None:
         if self._block_opened:
             self._block_opened = False
             self._print_lines("::endgroup::")
@@ -43,5 +43,5 @@ class GithubOutput(TerminalBasedOutput):
         if status == "Failed":
             self._print_lines(f"::error::{num_str} {name} - Failed")
 
-    def log_skipped(self, message):
+    def log_skipped(self, message: str) -> None:
         self._print_lines(message, prefix="::warning::")

--- a/universum/modules/output/github_output.py
+++ b/universum/modules/output/github_output.py
@@ -40,7 +40,7 @@ class GithubOutput(TerminalBasedOutput):
     def report_skipped(self, message):
         self.print_lines(message, prefix="::warning::")
 
-    def log_exception(self, line):
+    def log_error(self, line):
         self.print_lines(line, prefix="::error::")
 
     def log_stderr(self, line):

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -45,22 +45,16 @@ class HtmlOutput(BaseOutput):
         self._log_line(f"{indent} \u2514 {status_html}{closing_html}", with_line_separator=False)
         self._log_line("")
 
-    def report_error(self, description):
-        pass
-
-    def report_skipped(self, message):
+    def log_skipped(self, message):
         self._log_line(f'<span class="skipped">{message}</span>')
 
-    def report_step(self, step_title, has_children, status):
+    def log_summary_step(self, step_title, has_children, status):
         if not has_children:
             step_title += f' - <span class="{status.lower()}Status">{status}</span>'
         self.log(step_title)
 
-    def change_status(self, message):
-        pass
-
-    def log_error(self, line):
-        self._log_line(f'<span class="exceptionTag">Error:</span> {line}')
+    def log_error(self, description):
+        self._log_line(f'<span class="exceptionTag">Error:</span> {description}')
 
     def log_stdout(self, line):
         self._log_line(line)
@@ -91,6 +85,12 @@ class HtmlOutput(BaseOutput):
             html_footer += f"<script>{js_file.read()}</script>"
         html_footer += "</body></html>"
         self._log_line(html_footer)
+
+    def report_build_problem(self, description):
+        raise RuntimeError("Html output doesn't support reporting build problem.")
+
+    def set_build_title(self, message):
+        raise RuntimeError("Html output doesn't support setting build title.")
 
     def _log_line(self, line, with_line_separator=True):
         if with_line_separator and not line.endswith(os.linesep):

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -26,8 +26,38 @@ class HtmlOutput(BaseOutput):
         self.module_dir = os.path.dirname(os.path.realpath(__file__))
         self.ansi_converter = Ansi2HTMLConverter(inline=True, escaped=False)
 
-    def set_artifact_dir(self, artifact_dir):
-        self._log_path = os.path.join(artifact_dir, self._log_name)
+    def log_execution_start(self, title, version):
+        head_content = self._build_html_head()
+        html_header = f"<!DOCTYPE html><html><head>{head_content}</head><body>"
+        html_header += '<input type="checkbox" id="dark-checkbox"><label for="dark-checkbox"></label>'
+        html_header += '<input type="checkbox" id="time-checkbox"><label for="time-checkbox"></label>'
+        html_header += '<pre>'
+
+        self._log_buffered(html_header)
+        self.log(self._build_execution_start_msg(title, version))
+
+    def log_execution_finish(self, title, version):
+        self.log(self._build_execution_finish_msg(title, version))
+        html_footer = "</pre>"
+        with open(os.path.join(self.module_dir, "html_output.js"), encoding="utf-8") as js_file:
+            html_footer += f"<script>{js_file.read()}</script>"
+        html_footer += "</body></html>"
+        self._log_line(html_footer)
+
+    def log(self, line):
+        self._log_line(f"==> {line}")
+
+    def log_error(self, description):
+        self._log_line(f'<span class="exceptionTag">Error:</span> {description}')
+
+    def log_external_command(self, command):
+        self._log_line(f"$ {command}")
+
+    def log_stdout(self, line):
+        self._log_line(line)
+
+    def log_stderr(self, line):
+        self._log_line(f'<span class="stderrTag">stderr:</span> {line}')
 
     def open_block(self, num_str, name):
         opening_html = f'<input type="checkbox" id="{num_str}" class="hide"/>' + \
@@ -53,44 +83,14 @@ class HtmlOutput(BaseOutput):
             step_title += f' - <span class="{status.lower()}Status">{status}</span>'
         self.log(step_title)
 
-    def log_error(self, description):
-        self._log_line(f'<span class="exceptionTag">Error:</span> {description}')
-
-    def log_stdout(self, line):
-        self._log_line(line)
-
-    def log_stderr(self, line):
-        self._log_line(f'<span class="stderrTag">stderr:</span> {line}')
-
-    def log(self, line):
-        self._log_line(f"==> {line}")
-
-    def log_external_command(self, command):
-        self._log_line(f"$ {command}")
-
-    def log_execution_start(self, title, version):
-        head_content = self._build_html_head()
-        html_header = f"<!DOCTYPE html><html><head>{head_content}</head><body>"
-        html_header += '<input type="checkbox" id="dark-checkbox"><label for="dark-checkbox"></label>'
-        html_header += '<input type="checkbox" id="time-checkbox"><label for="time-checkbox"></label>'
-        html_header += '<pre>'
-
-        self._log_buffered(html_header)
-        self.log(self._build_execution_start_msg(title, version))
-
-    def log_execution_finish(self, title, version):
-        self.log(self._build_execution_finish_msg(title, version))
-        html_footer = "</pre>"
-        with open(os.path.join(self.module_dir, "html_output.js"), encoding="utf-8") as js_file:
-            html_footer += f"<script>{js_file.read()}</script>"
-        html_footer += "</body></html>"
-        self._log_line(html_footer)
-
     def report_build_problem(self, description):
         raise RuntimeError("Html output doesn't support reporting build problem.")
 
     def set_build_title(self, message):
         raise RuntimeError("Html output doesn't support setting build title.")
+
+    def set_artifact_dir(self, artifact_dir):
+        self._log_path = os.path.join(artifact_dir, self._log_name)
 
     def _log_line(self, line, with_line_separator=True):
         if with_line_separator and not line.endswith(os.linesep):

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -63,6 +63,9 @@ class HtmlOutput(BaseOutput):
     def log_exception(self, line):
         self._log_line(f'<span class="exceptionTag">Error:</span> {line}')
 
+    def log_stdout(self, line):
+        self._log_line(line)
+
     def log_stderr(self, line):
         self._log_line(f'<span class="stderrTag">stderr:</span> {line}')
 
@@ -71,9 +74,6 @@ class HtmlOutput(BaseOutput):
 
     def log_external_command(self, command):
         self._log_line(f"$ {command}")
-
-    def log_shell_output(self, line):
-        self._log_line(line)
 
     def log_execution_start(self, title, version):
         head_content = self._build_html_head()

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -2,7 +2,7 @@ import os
 import re
 from datetime import datetime
 from re import Match
-from typing import Optional
+from typing import Optional, List
 
 from ansi2html import Ansi2HTMLConverter
 
@@ -21,7 +21,7 @@ class HtmlOutput(BaseOutput):
         self._log_name: str = log_name
         self._log_path: Optional[str] = None
         self.artifact_dir_ready: bool = False
-        self._log_buffer: list[str] = []
+        self._log_buffer: List[str] = []
         self._block_level: int = 0
         self.module_dir: str = os.path.dirname(os.path.realpath(__file__))
         self.ansi_converter: Ansi2HTMLConverter = Ansi2HTMLConverter(inline=True, escaped=False)
@@ -120,14 +120,14 @@ class HtmlOutput(BaseOutput):
             file.write(line)
 
     def _build_indent(self) -> str:
-        indent_str: list[str] = []
+        indent_str: List[str] = []
         for x in range(0, self._block_level):  # type: int
             indent_str.append("  " * x)
             indent_str.append(" |   ")
         return "".join(indent_str)
 
     def _build_html_head(self) -> str:
-        head: list[str] = ['<meta content="text/html;charset=utf-8" http-equiv="Content-Type">',
+        head: List[str] = ['<meta content="text/html;charset=utf-8" http-equiv="Content-Type">',
                            '<meta content="utf-8" http-equiv="encoding">']
         with open(os.path.join(self.module_dir, "html_output.css"), encoding="utf-8") as css_file:
             head.append(f"<style>{css_file.read()}</style>")

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -60,7 +60,7 @@ class HtmlOutput(BaseOutput):
     def change_status(self, message):
         pass
 
-    def log_exception(self, line):
+    def log_error(self, line):
         self._log_line(f'<span class="exceptionTag">Error:</span> {line}')
 
     def log_stdout(self, line):

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -51,11 +51,10 @@ class HtmlOutput(BaseOutput):
     def report_skipped(self, message):
         self._log_line(f'<span class="skipped">{message}</span>')
 
-    def report_step(self, message, status):
-        if message.endswith(status):
-            message = message[:-len(status)]
-            message += f'<span class="{status.lower()}Status">{status}</span>'
-        self.log(message)
+    def report_step(self, step_title, has_children, status):
+        if not has_children:
+            step_title += f' - <span class="{status.lower()}Status">{status}</span>'
+        self.log(step_title)
 
     def change_status(self, message):
         pass

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -86,7 +86,7 @@ class HtmlOutput(BaseOutput):
     def report_build_problem(self, description: str) -> None:
         raise RuntimeError("Html output doesn't support reporting build problem.")
 
-    def set_build_title(self, message: str) -> None:
+    def set_build_title(self, title: str) -> None:
         raise RuntimeError("Html output doesn't support setting build title.")
 
     def set_artifact_dir(self, artifact_dir: str) -> None:

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -6,14 +6,12 @@ from ansi2html import Ansi2HTMLConverter
 
 from .base_output import BaseOutput
 
-
 __all__ = [
     "HtmlOutput"
 ]
 
 
 class HtmlOutput(BaseOutput):
-
     default_name = "universum_log.html"
 
     def __init__(self, *args, log_name=default_name, **kwargs):
@@ -61,7 +59,7 @@ class HtmlOutput(BaseOutput):
 
     def open_block(self, num_str, name):
         opening_html = f'<input type="checkbox" id="{num_str}" class="hide"/>' + \
-            f'<label for="{num_str}"><span class="sectionLbl">'
+                       f'<label for="{num_str}"><span class="sectionLbl">'
         closing_html = "</span></label><div>"
         name_html = f'<span class="sectionTitle">{name}</span>'
         self._log_line(f"{opening_html}{num_str} {name_html}{closing_html}", with_line_separator=False)
@@ -126,9 +124,8 @@ class HtmlOutput(BaseOutput):
         return "".join(indent_str)
 
     def _build_html_head(self):
-        head = []
-        head.append('<meta content="text/html;charset=utf-8" http-equiv="Content-Type">')
-        head.append('<meta content="utf-8" http-equiv="encoding">')
+        head = ['<meta content="text/html;charset=utf-8" http-equiv="Content-Type">',
+                '<meta content="utf-8" http-equiv="encoding">']
         with open(os.path.join(self.module_dir, "html_output.css"), encoding="utf-8") as css_file:
             head.append(f"<style>{css_file.read()}</style>")
         return "".join(head)

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -108,7 +108,7 @@ class HtmlOutput(BaseOutput):
         self._write_to_file(line)
 
     def _log_and_clear_buffer(self) -> None:
-        for buffered_line in self._log_buffer:  # type: str
+        for buffered_line in self._log_buffer:
             self._write_to_file(buffered_line)
         self._log_buffer = []
 
@@ -121,7 +121,7 @@ class HtmlOutput(BaseOutput):
 
     def _build_indent(self) -> str:
         indent_str: List[str] = []
-        for x in range(0, self._block_level):  # type: int
+        for x in range(0, self._block_level):
             indent_str.append("  " * x)
             indent_str.append(" |   ")
         return "".join(indent_str)
@@ -140,7 +140,7 @@ class HtmlOutput(BaseOutput):
     def _wrap_links(line: str) -> str:
         position_shift: int = 0
         pattern = r"(?:http|https|ftp|file|mailto):(?:\\ |\S)+"
-        for match in re.finditer(pattern, line):  # type: Match[str]
+        for match in re.finditer(pattern, line):
             link: str = match.group()
             wrapped_link: str = f'<a href="{link}">{link}</a>'
             link_start_pos: int = match.start() + position_shift

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -1,6 +1,8 @@
 import os
 import re
 from datetime import datetime
+from re import Match
+from typing import Optional
 
 from ansi2html import Ansi2HTMLConverter
 
@@ -14,19 +16,19 @@ __all__ = [
 class HtmlOutput(BaseOutput):
     default_name = "universum_log.html"
 
-    def __init__(self, *args, log_name=default_name, **kwargs):
+    def __init__(self, *args, log_name: str = default_name, **kwargs):
         super().__init__(*args, **kwargs)
-        self._log_name = log_name
-        self._log_path = None
-        self.artifact_dir_ready = False
-        self._log_buffer = []
-        self._block_level = 0
-        self.module_dir = os.path.dirname(os.path.realpath(__file__))
-        self.ansi_converter = Ansi2HTMLConverter(inline=True, escaped=False)
+        self._log_name: str = log_name
+        self._log_path: Optional[str] = None
+        self.artifact_dir_ready: bool = False
+        self._log_buffer: list[str] = []
+        self._block_level: int = 0
+        self.module_dir: str = os.path.dirname(os.path.realpath(__file__))
+        self.ansi_converter: Ansi2HTMLConverter = Ansi2HTMLConverter(inline=True, escaped=False)
 
-    def log_execution_start(self, title, version):
-        head_content = self._build_html_head()
-        html_header = f"<!DOCTYPE html><html><head>{head_content}</head><body>"
+    def log_execution_start(self, title: str, version: str) -> None:
+        head_content: str = self._build_html_head()
+        html_header: str = f"<!DOCTYPE html><html><head>{head_content}</head><body>"
         html_header += '<input type="checkbox" id="dark-checkbox"><label for="dark-checkbox"></label>'
         html_header += '<input type="checkbox" id="time-checkbox"><label for="time-checkbox"></label>'
         html_header += '<pre>'
@@ -34,70 +36,68 @@ class HtmlOutput(BaseOutput):
         self._log_buffered(html_header)
         self.log(self._build_execution_start_msg(title, version))
 
-    def log_execution_finish(self, title, version):
+    def log_execution_finish(self, title: str, version: str) -> None:
         self.log(self._build_execution_finish_msg(title, version))
-        html_footer = "</pre>"
+        html_footer: str = "</pre>"
         with open(os.path.join(self.module_dir, "html_output.js"), encoding="utf-8") as js_file:
             html_footer += f"<script>{js_file.read()}</script>"
         html_footer += "</body></html>"
         self._log_line(html_footer)
 
-    def log(self, line):
+    def log(self, line: str) -> None:
         self._log_line(f"==> {line}")
 
-    def log_error(self, description):
+    def log_error(self, description: str) -> None:
         self._log_line(f'<span class="exceptionTag">Error:</span> {description}')
 
-    def log_external_command(self, command):
+    def log_external_command(self, command: str) -> None:
         self._log_line(f"$ {command}")
 
-    def log_stdout(self, line):
+    def log_stdout(self, line: str) -> None:
         self._log_line(line)
 
-    def log_stderr(self, line):
+    def log_stderr(self, line: str) -> None:
         self._log_line(f'<span class="stderrTag">stderr:</span> {line}')
 
-    def open_block(self, num_str, name):
-        opening_html = f'<input type="checkbox" id="{num_str}" class="hide"/>' + \
-                       f'<label for="{num_str}"><span class="sectionLbl">'
-        closing_html = "</span></label><div>"
-        name_html = f'<span class="sectionTitle">{name}</span>'
+    def open_block(self, num_str: str, name: str) -> None:
+        opening_html: str = f'<input type="checkbox" id="{num_str}" class="hide"/>' + \
+                            f'<label for="{num_str}"><span class="sectionLbl">'
+        closing_html: str = "</span></label><div>"
+        name_html: str = f'<span class="sectionTitle">{name}</span>'
         self._log_line(f"{opening_html}{num_str} {name_html}{closing_html}", with_line_separator=False)
         self._block_level += 1
 
-    def close_block(self, num_str, name, status):
+    def close_block(self, num_str: str, name: str, status: str) -> None:
         self._block_level -= 1
-        indent = "  " * self._block_level
-        closing_html = '</div><span class="nl"></span>'
-        status_html = f'<span class="{status.lower()}Status">[{status}]</span>'
+        indent: str = "  " * self._block_level
+        closing_html: str = '</div><span class="nl"></span>'
+        status_html: str = f'<span class="{status.lower()}Status">[{status}]</span>'
         self._log_line(f"{indent} \u2514 {status_html}{closing_html}", with_line_separator=False)
         self._log_line("")
 
-    def log_skipped(self, message):
+    def log_skipped(self, message: str) -> None:
         self._log_line(f'<span class="skipped">{message}</span>')
 
-    def log_summary_step(self, step_title, has_children, status):
+    def log_summary_step(self, step_title: str, has_children: bool, status: str) -> None:
         if not has_children:
             step_title += f' - <span class="{status.lower()}Status">{status}</span>'
         self.log(step_title)
 
-    def report_build_problem(self, description):
+    def report_build_problem(self, description: str) -> None:
         raise RuntimeError("Html output doesn't support reporting build problem.")
 
-    def set_build_title(self, message):
+    def set_build_title(self, message: str) -> None:
         raise RuntimeError("Html output doesn't support setting build title.")
 
-    def set_artifact_dir(self, artifact_dir):
+    def set_artifact_dir(self, artifact_dir: str) -> None:
         self._log_path = os.path.join(artifact_dir, self._log_name)
 
-    def _log_line(self, line, with_line_separator=True):
+    def _log_line(self, line: str, with_line_separator: bool = True) -> None:
         if with_line_separator and not line.endswith(os.linesep):
             line += os.linesep
         self._log_buffered(self._build_time_stamp() + self._build_indent() + line)
 
-    def _log_buffered(self, line):
-        if not self._log_path:
-            raise RuntimeError("Artifact directory was not set")
+    def _log_buffered(self, line: str) -> None:
         line = self._wrap_links(line)
         line = self._ansi_codes_to_html(line)
         if not self.artifact_dir_ready:
@@ -107,46 +107,49 @@ class HtmlOutput(BaseOutput):
             self._log_and_clear_buffer()
         self._write_to_file(line)
 
-    def _log_and_clear_buffer(self):
-        for buffered_line in self._log_buffer:
+    def _log_and_clear_buffer(self) -> None:
+        for buffered_line in self._log_buffer:  # type: str
             self._write_to_file(buffered_line)
         self._log_buffer = []
 
-    def _write_to_file(self, line):
+    def _write_to_file(self, line: str) -> None:
+        if not self._log_path:
+            raise RuntimeError("Artifact directory was not set")
+
         with open(self._log_path, "a", encoding="utf-8") as file:
             file.write(line)
 
-    def _build_indent(self):
-        indent_str = []
-        for x in range(0, self._block_level):
+    def _build_indent(self) -> str:
+        indent_str: list[str] = []
+        for x in range(0, self._block_level):  # type: int
             indent_str.append("  " * x)
             indent_str.append(" |   ")
         return "".join(indent_str)
 
-    def _build_html_head(self):
-        head = ['<meta content="text/html;charset=utf-8" http-equiv="Content-Type">',
-                '<meta content="utf-8" http-equiv="encoding">']
+    def _build_html_head(self) -> str:
+        head: list[str] = ['<meta content="text/html;charset=utf-8" http-equiv="Content-Type">',
+                           '<meta content="utf-8" http-equiv="encoding">']
         with open(os.path.join(self.module_dir, "html_output.css"), encoding="utf-8") as css_file:
             head.append(f"<style>{css_file.read()}</style>")
         return "".join(head)
 
-    def _ansi_codes_to_html(self, line):
+    def _ansi_codes_to_html(self, line: str) -> str:
         return self.ansi_converter.convert(line, full=False)
 
     @staticmethod
-    def _wrap_links(line):
-        position_shift = 0
+    def _wrap_links(line: str) -> str:
+        position_shift: int = 0
         pattern = r"(?:http|https|ftp|file|mailto):(?:\\ |\S)+"
-        for match in re.finditer(pattern, line):
-            link = match.group()
-            wrapped_link = f'<a href="{link}">{link}</a>'
-            link_start_pos = match.start() + position_shift
-            link_end_pos = match.end() + position_shift
+        for match in re.finditer(pattern, line):  # type: Match[str]
+            link: str = match.group()
+            wrapped_link: str = f'<a href="{link}">{link}</a>'
+            link_start_pos: int = match.start() + position_shift
+            link_end_pos: int = match.end() + position_shift
             line = line[:link_start_pos] + wrapped_link + line[link_end_pos:]
             position_shift += len(wrapped_link) - len(link)
         return line
 
     @staticmethod
-    def _build_time_stamp():
+    def _build_time_stamp() -> str:
         now = datetime.now()
         return now.astimezone().strftime('<span class="time" title="%Z (UTC%z)">%Y-%m-%d %H:%M:%S</span> ')

--- a/universum/modules/output/html_output.py
+++ b/universum/modules/output/html_output.py
@@ -86,7 +86,7 @@ class HtmlOutput(BaseOutput):
     def report_build_problem(self, description: str) -> None:
         raise RuntimeError("Html output doesn't support reporting build problem.")
 
-    def set_build_title(self, title: str) -> None:
+    def set_build_status(self, status: str) -> None:
         raise RuntimeError("Html output doesn't support setting build title.")
 
     def set_artifact_dir(self, artifact_dir: str) -> None:

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -82,9 +82,9 @@ class Output(Module):
         self.driver.report_step(message, status)
         self.html_driver.report_step(message, status)
 
-    def log_exception(self, line: str) -> None:
-        self.driver.log_exception(line)
-        self.html_driver.log_exception(line)
+    def log_error(self, line: str) -> None:
+        self.driver.log_error(line)
+        self.html_driver.log_error(line)
 
     def log_stdout(self, line: str) -> None:
         self.driver.log_stdout(line)
@@ -130,9 +130,8 @@ class MinimalOut:
         pass
 
     @staticmethod
-    def log_exception(exc: Exception) -> None:
-        ex_traceback: Optional[TracebackType] = sys.exc_info()[2]
-        sys.stderr.write("Unexpected error.\n" + utils.format_traceback(exc, ex_traceback))
+    def log_error(line: str) -> None:
+        sys.stderr.write("Error: " + line)
 
     def log_execution_start(self, title, version):
         pass

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -65,26 +65,24 @@ class Output(Module):
         self.driver.close_block(number, name, status)
         self.html_driver.close_block(number, name, status)
 
-    def report_build_status(self, status: str) -> None:
-        self.driver.change_status(status)
-        self.html_driver.change_status(status)
+    def set_build_title(self, status: str) -> None:
+        self.driver.set_build_title(status)
 
     # TODO: pass build problem to the Report module
     def report_build_problem(self, problem: str) -> None:
-        self.driver.report_error(problem)
-        self.html_driver.report_error(problem)
+        self.driver.report_build_problem(problem)
 
-    def report_skipped(self, message: str) -> None:
-        self.driver.report_skipped(message)
-        self.html_driver.report_skipped(message)
+    def log_skipped(self, message: str) -> None:
+        self.driver.log_skipped(message)
+        self.html_driver.log_skipped(message)
 
-    def report_step(self, step_title: str, has_children: bool, status: str) -> None:
-        self.driver.report_step(step_title, has_children, status)
-        self.html_driver.report_step(step_title, has_children, status)
+    def log_summary_step(self, step_title: str, has_children: bool, status: str) -> None:
+        self.driver.log_summary_step(step_title, has_children, status)
+        self.html_driver.log_summary_step(step_title, has_children, status)
 
-    def log_error(self, line: str) -> None:
-        self.driver.log_error(line)
-        self.html_driver.log_error(line)
+    def log_error(self, description: str) -> None:
+        self.driver.log_error(description)
+        self.html_driver.log_error(description)
 
     def log_stdout(self, line: str) -> None:
         self.driver.log_stdout(line)

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -1,15 +1,13 @@
 import sys
-import os
-from types import TracebackType
-from typing import ClassVar, Optional
+from typing import ClassVar
 
-from ...lib.gravity import Module, Dependency
-from ...lib import utils
 from .base_output import BaseOutput
 from .github_output import GithubOutput
-from .terminal_based_output import TerminalBasedOutput
-from .teamcity_output import TeamcityOutput
 from .html_output import HtmlOutput
+from .teamcity_output import TeamcityOutput
+from .terminal_based_output import TerminalBasedOutput
+from ...lib import utils
+from ...lib.gravity import Module, Dependency
 
 __all__ = [
     "HasOutput",

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -78,9 +78,9 @@ class Output(Module):
         self.driver.report_skipped(message)
         self.html_driver.report_skipped(message)
 
-    def report_step(self, message: str, status: str) -> None:
-        self.driver.report_step(message, status)
-        self.html_driver.report_step(message, status)
+    def report_step(self, step_title: str, has_children: bool, status: str) -> None:
+        self.driver.report_step(step_title, has_children, status)
+        self.html_driver.report_step(step_title, has_children, status)
 
     def log_error(self, line: str) -> None:
         self.driver.log_error(line)

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -49,40 +49,25 @@ class Output(Module):
                                 env_type=self.settings.type)
         self.html_driver = self._create_html_driver()
 
+    def log_execution_start(self, title: str, version: str) -> None:
+        self.driver.log_execution_start(title, version)
+        self.html_driver.log_execution_start(title, version)
+
+    def log_execution_finish(self, title: str, version: str) -> None:
+        self.driver.log_execution_finish(title, version)
+        self.html_driver.log_execution_finish(title, version)
+
     def log(self, line: str) -> None:
         self.driver.log(line)
         self.html_driver.log(line)
 
-    def log_external_command(self, command: str) -> None:
-        self.driver.log_external_command(command)
-        self.html_driver.log_external_command(command)
-
-    def open_block(self, number: str, name: str) -> None:
-        self.driver.open_block(number, name)
-        self.html_driver.open_block(number, name)
-
-    def close_block(self, number: str, name: str, status: str) -> None:
-        self.driver.close_block(number, name, status)
-        self.html_driver.close_block(number, name, status)
-
-    def set_build_title(self, status: str) -> None:
-        self.driver.set_build_title(status)
-
-    # TODO: pass build problem to the Report module
-    def report_build_problem(self, problem: str) -> None:
-        self.driver.report_build_problem(problem)
-
-    def log_skipped(self, message: str) -> None:
-        self.driver.log_skipped(message)
-        self.html_driver.log_skipped(message)
-
-    def log_summary_step(self, step_title: str, has_children: bool, status: str) -> None:
-        self.driver.log_summary_step(step_title, has_children, status)
-        self.html_driver.log_summary_step(step_title, has_children, status)
-
     def log_error(self, description: str) -> None:
         self.driver.log_error(description)
         self.html_driver.log_error(description)
+
+    def log_external_command(self, command: str) -> None:
+        self.driver.log_external_command(command)
+        self.html_driver.log_external_command(command)
 
     def log_stdout(self, line: str) -> None:
         self.driver.log_stdout(line)
@@ -92,13 +77,28 @@ class Output(Module):
         self.driver.log_stderr(line)
         self.html_driver.log_stderr(line)
 
-    def log_execution_start(self, title: str, version: str) -> None:
-        self.driver.log_execution_start(title, version)
-        self.html_driver.log_execution_start(title, version)
+    def open_block(self, number: str, name: str) -> None:
+        self.driver.open_block(number, name)
+        self.html_driver.open_block(number, name)
 
-    def log_execution_finish(self, title: str, version: str) -> None:
-        self.driver.log_execution_finish(title, version)
-        self.html_driver.log_execution_finish(title, version)
+    def close_block(self, number: str, name: str, status: str) -> None:
+        self.driver.close_block(number, name, status)
+        self.html_driver.close_block(number, name, status)
+
+    def log_skipped(self, message: str) -> None:
+        self.driver.log_skipped(message)
+        self.html_driver.log_skipped(message)
+
+    def log_summary_step(self, step_title: str, has_children: bool, status: str) -> None:
+        self.driver.log_summary_step(step_title, has_children, status)
+        self.html_driver.log_summary_step(step_title, has_children, status)
+
+    # TODO: pass build problem to the Report module
+    def report_build_problem(self, problem: str) -> None:
+        self.driver.report_build_problem(problem)
+
+    def set_build_title(self, status: str) -> None:
+        self.driver.set_build_title(status)
 
     def _create_html_driver(self):
         is_enabled = self.settings.html_log is not None

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -86,13 +86,13 @@ class Output(Module):
         self.driver.log_exception(line)
         self.html_driver.log_exception(line)
 
+    def log_stdout(self, line: str) -> None:
+        self.driver.log_stdout(line)
+        self.html_driver.log_stdout(line)
+
     def log_stderr(self, line: str) -> None:
         self.driver.log_stderr(line)
         self.html_driver.log_stderr(line)
-
-    def log_shell_output(self, line: str) -> None:
-        self.driver.log_shell_output(line)
-        self.html_driver.log_shell_output(line)
 
     def log_execution_start(self, title: str, version: str) -> None:
         self.driver.log_execution_start(title, version)

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -95,8 +95,8 @@ class Output(Module):
     def report_build_problem(self, problem: str) -> None:
         self.driver.report_build_problem(problem)
 
-    def set_build_title(self, status: str) -> None:
-        self.driver.set_build_title(status)
+    def set_build_title(self, title: str) -> None:
+        self.driver.set_build_title(title)
 
     def _create_html_driver(self):
         is_enabled = self.settings.html_log is not None

--- a/universum/modules/output/output.py
+++ b/universum/modules/output/output.py
@@ -95,8 +95,8 @@ class Output(Module):
     def report_build_problem(self, problem: str) -> None:
         self.driver.report_build_problem(problem)
 
-    def set_build_title(self, title: str) -> None:
-        self.driver.set_build_title(title)
+    def set_build_status(self, status: str) -> None:
+        self.driver.set_build_status(status)
 
     def _create_html_driver(self):
         is_enabled = self.settings.html_log is not None

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -15,7 +15,7 @@ class TeamcityOutput(BaseOutput):
 
     def log_error(self, description: str) -> None:
         lines = description.split("\n")
-        for single_line in lines:  # type: str
+        for single_line in lines:
             print(f"##teamcity[message text='{escape(single_line)}' status='ERROR']")
 
     def log_external_command(self, command: str) -> None:
@@ -26,7 +26,7 @@ class TeamcityOutput(BaseOutput):
 
     def log_stderr(self, line: str) -> None:
         lines = line.split("\n")
-        for single_line in lines:  # type: str
+        for single_line in lines:
             print(f"##teamcity[message text='{escape(single_line)}' status='WARNING']")
 
     def open_block(self, num_str: str, name: str) -> None:
@@ -37,7 +37,7 @@ class TeamcityOutput(BaseOutput):
 
     def log_skipped(self, message: str) -> None:
         lines = message.split("\n")
-        for single_line in lines:  # type: str
+        for single_line in lines:
             print(f"##teamcity[message text='{escape(single_line)}' status='WARNING']")
 
     def log_summary_step(self, step_title: str, has_children: bool, status: str) -> None:

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -32,6 +32,9 @@ class TeamcityOutput(BaseOutput):
         for single_line in lines:
             print(f"##teamcity[message text='{escape(single_line)}' status='ERROR']")
 
+    def log_stdout(self, line):
+        print(line)
+
     def log_stderr(self, line):
         lines = line.split("\n")
         for single_line in lines:
@@ -42,6 +45,3 @@ class TeamcityOutput(BaseOutput):
 
     def log_external_command(self, command):
         print("$", command)
-
-    def log_shell_output(self, line):
-        print(line)

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -10,14 +10,30 @@ def escape(message):
 
 
 class TeamcityOutput(BaseOutput):
+    def log(self, line):
+        print("==>", line)
+
+    def log_error(self, description):
+        lines = description.split("\n")
+        for single_line in lines:
+            print(f"##teamcity[message text='{escape(single_line)}' status='ERROR']")
+
+    def log_external_command(self, command):
+        print("$", command)
+
+    def log_stdout(self, line):
+        print(line)
+
+    def log_stderr(self, line):
+        lines = line.split("\n")
+        for single_line in lines:
+            print(f"##teamcity[message text='{escape(single_line)}' status='WARNING']")
+
     def open_block(self, num_str, name):
         print(f"##teamcity[blockOpened name='{num_str} {escape(name)}']")
 
     def close_block(self, num_str, name, status):
-        print(f"##teamcity[blockClosed name='{num_str} {escape(name)}']")
-
-    def report_build_problem(self, description):
-        print(f"##teamcity[buildProblem description='<{escape(description)}>']")
+        print(f"##teamcity[block\\Closed name='{num_str} {escape(name)}']")
 
     def log_skipped(self, message):
         lines = message.split("\n")
@@ -30,24 +46,12 @@ class TeamcityOutput(BaseOutput):
         else:
             self.log(f"{step_title} - {status}")
 
+    def report_build_problem(self, description):
+        print(f"##teamcity[buildProblem description='<{escape(description)}>']")
+
     def set_build_title(self, message):
         print(f"##teamcity[buildStatus text='{escape(message)}']")
 
-    def log_error(self, description):
-        lines = description.split("\n")
-        for single_line in lines:
-            print(f"##teamcity[message text='{escape(single_line)}' status='ERROR']")
 
-    def log_stdout(self, line):
-        print(line)
 
-    def log_stderr(self, line):
-        lines = line.split("\n")
-        for single_line in lines:
-            print(f"##teamcity[message text='{escape(single_line)}' status='WARNING']")
 
-    def log(self, line):
-        print("==>", line)
-
-    def log_external_command(self, command):
-        print("$", command)

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -5,49 +5,49 @@ __all__ = [
 ]
 
 
-def escape(message):
+def escape(message: str) -> str:
     return message.replace('\r', '').replace('|', '||').replace('\'', '|\'').replace('[', '|[').replace(']', '|]')
 
 
 class TeamcityOutput(BaseOutput):
-    def log(self, line):
+    def log(self, line: str):
         print("==>", line)
 
-    def log_error(self, description):
+    def log_error(self, description: str) -> None:
         lines = description.split("\n")
-        for single_line in lines:
+        for single_line in lines:  # type: str
             print(f"##teamcity[message text='{escape(single_line)}' status='ERROR']")
 
-    def log_external_command(self, command):
+    def log_external_command(self, command: str) -> None:
         print("$", command)
 
-    def log_stdout(self, line):
+    def log_stdout(self, line: str) -> None:
         print(line)
 
-    def log_stderr(self, line):
+    def log_stderr(self, line: str) -> None:
         lines = line.split("\n")
-        for single_line in lines:
+        for single_line in lines:  # type: str
             print(f"##teamcity[message text='{escape(single_line)}' status='WARNING']")
 
-    def open_block(self, num_str, name):
+    def open_block(self, num_str: str, name: str) -> None:
         print(f"##teamcity[blockOpened name='{num_str} {escape(name)}']")
 
-    def close_block(self, num_str, name, status):
+    def close_block(self, num_str: str, name: str, status: str) -> None:
         print(f"##teamcity[block\\Closed name='{num_str} {escape(name)}']")
 
-    def log_skipped(self, message):
+    def log_skipped(self, message: str) -> None:
         lines = message.split("\n")
-        for single_line in lines:
+        for single_line in lines:  # type: str
             print(f"##teamcity[message text='{escape(single_line)}' status='WARNING']")
 
-    def log_summary_step(self, step_title, has_children, status):
+    def log_summary_step(self, step_title: str, has_children: bool, status: str) -> None:
         if has_children:
             self.log(step_title)
         else:
             self.log(f"{step_title} - {status}")
 
-    def report_build_problem(self, description):
+    def report_build_problem(self, description: str) -> None:
         print(f"##teamcity[buildProblem description='<{escape(description)}>']")
 
-    def set_build_title(self, message):
+    def set_build_title(self, message: str) -> None:
         print(f"##teamcity[buildStatus text='{escape(message)}']")

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -49,5 +49,5 @@ class TeamcityOutput(BaseOutput):
     def report_build_problem(self, description: str) -> None:
         print(f"##teamcity[buildProblem description='<{escape(description)}>']")
 
-    def set_build_title(self, message: str) -> None:
-        print(f"##teamcity[buildStatus text='{escape(message)}']")
+    def set_build_title(self, title: str) -> None:
+        print(f"##teamcity[buildStatus text='{escape(title)}']")

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -24,6 +24,13 @@ class TeamcityOutput(BaseOutput):
         for single_line in lines:
             print(f"##teamcity[message text='{escape(single_line)}' status='WARNING']")
 
+    def report_step(self, step_title, has_children, status):
+        if has_children:
+            self.log(step_title)
+        else:
+            self.log(f"{step_title} - {status}")
+
+
     def change_status(self, message):
         print(f"##teamcity[buildStatus text='{escape(message)}']")
 

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -49,5 +49,5 @@ class TeamcityOutput(BaseOutput):
     def report_build_problem(self, description: str) -> None:
         print(f"##teamcity[buildProblem description='<{escape(description)}>']")
 
-    def set_build_title(self, title: str) -> None:
-        print(f"##teamcity[buildStatus text='{escape(title)}']")
+    def set_build_status(self, status: str) -> None:
+        print(f"##teamcity[buildStatus text='{escape(status)}']")

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -16,26 +16,25 @@ class TeamcityOutput(BaseOutput):
     def close_block(self, num_str, name, status):
         print(f"##teamcity[blockClosed name='{num_str} {escape(name)}']")
 
-    def report_error(self, description):
+    def report_build_problem(self, description):
         print(f"##teamcity[buildProblem description='<{escape(description)}>']")
 
-    def report_skipped(self, message):
+    def log_skipped(self, message):
         lines = message.split("\n")
         for single_line in lines:
             print(f"##teamcity[message text='{escape(single_line)}' status='WARNING']")
 
-    def report_step(self, step_title, has_children, status):
+    def log_summary_step(self, step_title, has_children, status):
         if has_children:
             self.log(step_title)
         else:
             self.log(f"{step_title} - {status}")
 
-
-    def change_status(self, message):
+    def set_build_title(self, message):
         print(f"##teamcity[buildStatus text='{escape(message)}']")
 
-    def log_error(self, line):
-        lines = line.split("\n")
+    def log_error(self, description):
+        lines = description.split("\n")
         for single_line in lines:
             print(f"##teamcity[message text='{escape(single_line)}' status='ERROR']")
 

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -51,7 +51,3 @@ class TeamcityOutput(BaseOutput):
 
     def set_build_title(self, message):
         print(f"##teamcity[buildStatus text='{escape(message)}']")
-
-
-
-

--- a/universum/modules/output/teamcity_output.py
+++ b/universum/modules/output/teamcity_output.py
@@ -27,7 +27,7 @@ class TeamcityOutput(BaseOutput):
     def change_status(self, message):
         print(f"##teamcity[buildStatus text='{escape(message)}']")
 
-    def log_exception(self, line):
+    def log_error(self, line):
         lines = line.split("\n")
         for single_line in lines:
             print(f"##teamcity[message text='{escape(single_line)}' status='ERROR']")

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -67,15 +67,15 @@ class TerminalBasedOutput(BaseOutput):
     def report_skipped(self, message):
         self.print_lines(Colors.dark_cyan, message, Colors.reset)
 
-    def report_step(self, message, status):
+    def report_step(self, step_title, has_children, status):
         color = Colors.red
         if status.lower() == "success":
             color = Colors.green
 
-        if message.endswith(status):
-            message = message[:-len(status)]
-            message += color + status + Colors.reset
-        self.log(message)
+        if not has_children:
+            step_title += " - " + color + status + Colors.reset
+
+        self.log(step_title)
 
     def change_status(self, message):
         pass

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -19,49 +19,49 @@ class Colors:
 
 
 class TerminalBasedOutput(BaseOutput):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.block_level = 0
         self.unicode_acceptable = (locale.getpreferredencoding() == "UTF-8")
 
     @staticmethod
-    def _stdout(*args, **kwargs):
+    def _stdout(*args, **kwargs) -> None:
         sys.stdout.write(''.join(args))
         if not kwargs.get("no_enter", False):
             sys.stdout.write('\n')
 
-    def _indent(self):
+    def _indent(self) -> None:
         for x in range(0, self.block_level):
             self._stdout("  " * x, " |   ", no_enter=True)
 
-    def _print_lines(self, *args, **kwargs):
-        result = ''.join(args)
-        lines = result.splitlines(False)
-        for line in lines:
+    def _print_lines(self, *args, **kwargs) -> None:
+        result: str = ''.join(args)
+        lines: list[str] = result.splitlines(False)
+        for line in lines:  # type: str
             self._indent()
             self._stdout(line)
 
-    def log(self, line):
+    def log(self, line: str) -> None:
         self._print_lines("==> ", line)
 
-    def log_error(self, description):
+    def log_error(self, description: str) -> None:
         self._print_lines(Colors.dark_red, "Error: ", Colors.reset, description)
 
-    def log_external_command(self, command):
+    def log_external_command(self, command: str) -> None:
         self._print_lines("$ ", command)
 
-    def log_stdout(self, line):
+    def log_stdout(self, line: str) -> None:
         self._print_lines(line)
 
-    def log_stderr(self, line):
+    def log_stderr(self, line: str) -> None:
         self._print_lines(Colors.dark_yellow, "stderr: ", Colors.reset, line)
 
-    def open_block(self, num_str, name):
+    def open_block(self, num_str: str, name: str) -> None:
         self._indent()
         self._stdout(num_str, ' ', Colors.blue, name, Colors.reset)
         self.block_level += 1
 
-    def close_block(self, num_str, name, status):
+    def close_block(self, num_str: str, name: str, status: str) -> None:
         self.block_level -= 1
         self._indent()
         if self.unicode_acceptable:
@@ -76,10 +76,10 @@ class TerminalBasedOutput(BaseOutput):
         self._indent()
         self._stdout()
 
-    def log_skipped(self, message):
+    def log_skipped(self, message: str) -> None:
         self._print_lines(Colors.dark_cyan, message, Colors.reset)
 
-    def log_summary_step(self, step_title, has_children, status):
+    def log_summary_step(self, step_title: str, has_children: bool, status: str) -> None:
         color = Colors.red
         if status.lower() == "success":
             color = Colors.green
@@ -89,8 +89,8 @@ class TerminalBasedOutput(BaseOutput):
 
         self.log(step_title)
 
-    def report_build_problem(self, description):
+    def report_build_problem(self, description: str) -> None:
         pass
 
-    def set_build_title(self, message):
+    def set_build_title(self, message: str) -> None:
         pass

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -1,5 +1,6 @@
 import locale
 import sys
+from typing import List
 
 from .base_output import BaseOutput
 
@@ -36,7 +37,7 @@ class TerminalBasedOutput(BaseOutput):
 
     def _print_lines(self, *args, **kwargs) -> None:
         result: str = ''.join(args)
-        lines: list[str] = result.splitlines(False)
+        lines: List[str] = result.splitlines(False)
         for line in lines:  # type: str
             self._indent()
             self._stdout(line)

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -80,7 +80,7 @@ class TerminalBasedOutput(BaseOutput):
     def change_status(self, message):
         pass
 
-    def log_exception(self, line):
+    def log_error(self, line):
         self.print_lines(Colors.dark_red, "Error: ", Colors.reset, line)
 
     def log_stdout(self, line):

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -83,6 +83,9 @@ class TerminalBasedOutput(BaseOutput):
     def log_exception(self, line):
         self.print_lines(Colors.dark_red, "Error: ", Colors.reset, line)
 
+    def log_stdout(self, line):
+        self.print_lines(line)
+
     def log_stderr(self, line):
         self.print_lines(Colors.dark_yellow, "stderr: ", Colors.reset, line)
 
@@ -92,5 +95,3 @@ class TerminalBasedOutput(BaseOutput):
     def log_external_command(self, command):
         self.print_lines("$ ", command)
 
-    def log_shell_output(self, line):
-        self.print_lines(line)

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -61,13 +61,10 @@ class TerminalBasedOutput(BaseOutput):
         self.indent()
         self.stdout()
 
-    def report_error(self, description):
-        pass
-
-    def report_skipped(self, message):
+    def log_skipped(self, message):
         self.print_lines(Colors.dark_cyan, message, Colors.reset)
 
-    def report_step(self, step_title, has_children, status):
+    def log_summary_step(self, step_title, has_children, status):
         color = Colors.red
         if status.lower() == "success":
             color = Colors.green
@@ -77,11 +74,14 @@ class TerminalBasedOutput(BaseOutput):
 
         self.log(step_title)
 
-    def change_status(self, message):
+    def report_build_problem(self, description):
         pass
 
-    def log_error(self, line):
-        self.print_lines(Colors.dark_red, "Error: ", Colors.reset, line)
+    def set_build_title(self, message):
+        pass
+
+    def log_error(self, description):
+        self.print_lines(Colors.dark_red, "Error: ", Colors.reset, description)
 
     def log_stdout(self, line):
         self.print_lines(line)
@@ -94,4 +94,3 @@ class TerminalBasedOutput(BaseOutput):
 
     def log_external_command(self, command):
         self.print_lines("$ ", command)
-

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -25,44 +25,59 @@ class TerminalBasedOutput(BaseOutput):
         self.unicode_acceptable = (locale.getpreferredencoding() == "UTF-8")
 
     @staticmethod
-    def stdout(*args, **kwargs):
+    def _stdout(*args, **kwargs):
         sys.stdout.write(''.join(args))
         if not kwargs.get("no_enter", False):
             sys.stdout.write('\n')
 
-    def indent(self):
+    def _indent(self):
         for x in range(0, self.block_level):
-            self.stdout("  " * x, " |   ", no_enter=True)
+            self._stdout("  " * x, " |   ", no_enter=True)
 
-    def print_lines(self, *args, **kwargs):
+    def _print_lines(self, *args, **kwargs):
         result = ''.join(args)
         lines = result.splitlines(False)
         for line in lines:
-            self.indent()
-            self.stdout(line)
+            self._indent()
+            self._stdout(line)
+
+    def log(self, line):
+        self._print_lines("==> ", line)
+
+    def log_error(self, description):
+        self._print_lines(Colors.dark_red, "Error: ", Colors.reset, description)
+
+    def log_external_command(self, command):
+        self._print_lines("$ ", command)
+
+    def log_stdout(self, line):
+        self._print_lines(line)
+
+    def log_stderr(self, line):
+        self._print_lines(Colors.dark_yellow, "stderr: ", Colors.reset, line)
 
     def open_block(self, num_str, name):
-        self.indent()
-        self.stdout(num_str, ' ', Colors.blue, name, Colors.reset)
+        self._indent()
+        self._stdout(num_str, ' ', Colors.blue, name, Colors.reset)
         self.block_level += 1
 
     def close_block(self, num_str, name, status):
         self.block_level -= 1
-        self.indent()
+        self._indent()
         if self.unicode_acceptable:
             block_end = " \u2514 "
         else:
             block_end = " | "
 
         if status == "Failed":
-            self.stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
+            self._stdout(self.block_level * "  ", block_end, Colors.red, "[Failed]", Colors.reset)
         else:
-            self.stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
-        self.indent()
-        self.stdout()
+            self._stdout(self.block_level * "  ", block_end, Colors.green, "[Success]", Colors.reset)
+        self._indent()
+        self._stdout()
 
     def log_skipped(self, message):
-        self.print_lines(Colors.dark_cyan, message, Colors.reset)
+        self._print_lines(Colors.dark_cyan, message, Colors.reset)
 
     def log_summary_step(self, step_title, has_children, status):
         color = Colors.red
@@ -79,18 +94,3 @@ class TerminalBasedOutput(BaseOutput):
 
     def set_build_title(self, message):
         pass
-
-    def log_error(self, description):
-        self.print_lines(Colors.dark_red, "Error: ", Colors.reset, description)
-
-    def log_stdout(self, line):
-        self.print_lines(line)
-
-    def log_stderr(self, line):
-        self.print_lines(Colors.dark_yellow, "stderr: ", Colors.reset, line)
-
-    def log(self, line):
-        self.print_lines("==> ", line)
-
-    def log_external_command(self, command):
-        self.print_lines("$ ", command)

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -92,5 +92,5 @@ class TerminalBasedOutput(BaseOutput):
     def report_build_problem(self, description: str) -> None:
         pass
 
-    def set_build_title(self, message: str) -> None:
+    def set_build_title(self, title: str) -> None:
         pass

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -38,7 +38,7 @@ class TerminalBasedOutput(BaseOutput):
     def _print_lines(self, *args, **kwargs) -> None:
         result: str = ''.join(args)
         lines: List[str] = result.splitlines(False)
-        for line in lines:  # type: str
+        for line in lines:
             self._indent()
             self._stdout(line)
 

--- a/universum/modules/output/terminal_based_output.py
+++ b/universum/modules/output/terminal_based_output.py
@@ -93,5 +93,5 @@ class TerminalBasedOutput(BaseOutput):
     def report_build_problem(self, description: str) -> None:
         pass
 
-    def set_build_title(self, title: str) -> None:
+    def set_build_status(self, status: str) -> None:
         pass

--- a/universum/modules/reporter.py
+++ b/universum/modules/reporter.py
@@ -148,13 +148,13 @@ class Reporter(HasOutput, HasStructure):
         block_title: str = block.number + ' ' + block.name
         if not self.settings.only_fails:
             text += indent + str(block) + '\n'
-            self.out.report_step(indent + block_title, has_children, block.status)
+            self.out.log_summary_step(indent + block_title, has_children, block.status)
         elif not block.is_successful():
             text += str(block) + '\n'
-            self.out.report_step(block_title, has_children, block.status)
+            self.out.log_summary_step(block_title, has_children, block.status)
 
         is_successful = block.is_successful()
-        for substep in block.children:  # type: Block
-            text, status = self._report_steps_recursively(substep, text, indent + "  ")
+        for child in block.children:  # type: Block
+            text, status = self._report_steps_recursively(child, text, indent + "  ")
             is_successful = is_successful and status
         return text, is_successful

--- a/universum/modules/reporter.py
+++ b/universum/modules/reporter.py
@@ -155,7 +155,7 @@ class Reporter(HasOutput, HasStructure):
             self.out.log_summary_step(block_title, has_children, block.status)
 
         is_successful = block.is_successful()
-        for child in block.children:  # type: Block
+        for child in block.children:
             text, status = self._report_steps_recursively(child, text, indent + "  ")
             is_successful = is_successful and status
         return text, is_successful

--- a/universum/modules/reporter.py
+++ b/universum/modules/reporter.py
@@ -1,12 +1,13 @@
 from collections import defaultdict
 from typing import Dict, List, Tuple
+
 from typing_extensions import TypedDict
 
-from ..lib.gravity import Dependency
-from ..lib.utils import make_block
 from . import automation_server
 from .output import HasOutput
 from .structure_handler import HasStructure, Block
+from ..lib.gravity import Dependency
+from ..lib.utils import make_block
 
 __all__ = [
     "ReportObserver",

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
 import contextlib
-import copy
-
 from abc import ABC, abstractmethod
-from typing import Callable, ClassVar, List, Optional, TypeVar, Union, Generator
+from typing import Callable, ClassVar, List, Optional, TypeVar, Generator
+
 from typing_extensions import TypedDict
+
+from .output import HasOutput
 from ..configuration_support import Step, Configuration
 from ..lib.ci_exception import SilentAbortException, CriticalCiException
 from ..lib.gravity import Dependency, Module
-from .output import HasOutput
 
 __all__ = [
     "HasStructure",
-    "Block"
+    "Block",
+    "RunningStepBase"
 ]
 
 
@@ -185,7 +186,7 @@ class StructureHandler(HasOutput):
     def process_one_step(self, merged_item: Step, step_executor: Callable, skip_execution: bool) -> bool:
         """
         Process one step: either execute it or skip if the skip_execution flag is set.
-        :param merged_item: Step to execute
+        :param merged_item: Step to execute.
         :param step_executor: Function that executes one step.
         :param skip_execution: If True, the step will be skipped, but reported to the output.
         :return: True if step was successfully executed, False otherwise. Skipping is considered success.
@@ -261,7 +262,7 @@ class StructureHandler(HasOutput):
                 if not self.finalize_background_step(item) and item['is_critical']:
                     result = False
                     self.out.log_skipped("The background step '" + item['name'] + "' failed, and as it is critical, "
-                                            "all further steps will be skipped")
+                                                                                  "all further steps will be skipped")
 
         self.out.log("All ongoing background steps completed")
         self.active_background_steps = []

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -123,7 +123,7 @@ class StructureHandler(HasOutput):
 
     def fail_block(self, block, error: str = ""):
         if error:
-            self.out.log_exception(error)
+            self.out.log_error(error)
         block.status = "Failed"
         self.out.report_build_problem(block.name + " " + block.status)
 

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -12,7 +12,8 @@ from ..lib.gravity import Dependency, Module
 from .output import HasOutput
 
 __all__ = [
-    "HasStructure"
+    "HasStructure",
+    "Block"
 ]
 
 

--- a/universum/modules/structure_handler.py
+++ b/universum/modules/structure_handler.py
@@ -109,14 +109,14 @@ class StructureHandler(HasOutput):
             self.current_block = self.current_block.parent
             self.out.close_block(block.number, block.name, block.status)
 
-    def report_critical_block_failure(self) -> None:
-        self.out.report_skipped("Critical step failed. All further configurations will be skipped")
+    def log_critical_block_failure(self) -> None:
+        self.out.log_skipped("Critical step failed. All further configurations will be skipped")
 
-    def report_skipped_block(self, name):
+    def log_skipped_block(self, name):
         new_skipped_block = Block(name, self.current_block)
         new_skipped_block.status = "Skipped"
 
-        self.out.report_skipped(new_skipped_block.number + name + " skipped because of critical step failure")
+        self.out.log_skipped(new_skipped_block.number + name + " skipped because of critical step failure")
 
     def fail_current_block(self, error: str = ""):
         block: Block = self.get_current_block()
@@ -195,7 +195,7 @@ class StructureHandler(HasOutput):
         step_label: str = numbering + merged_item.name
 
         if skip_execution:
-            self.report_skipped_block(numbering + "'" + merged_item.name + "'")
+            self.log_skipped_block(numbering + "'" + merged_item.name + "'")
             return True
 
         # Here pass_errors=False, because any exception while executing build step
@@ -245,7 +245,7 @@ class StructureHandler(HasOutput):
                 some_step_failed = True
 
                 if child.critical:
-                    self.report_critical_block_failure()
+                    self.log_critical_block_failure()
                     skip_execution = True
 
         if some_step_failed:
@@ -260,7 +260,7 @@ class StructureHandler(HasOutput):
                             pass_errors=True):
                 if not self.finalize_background_step(item) and item['is_critical']:
                     result = False
-                    self.out.report_skipped("The background step '" + item['name'] + "' failed, and as it is critical, "
+                    self.out.log_skipped("The background step '" + item['name'] + "' failed, and as it is critical, "
                                             "all further steps will be skipped")
 
         self.out.log("All ongoing background steps completed")

--- a/universum/modules/vcs/base_vcs.py
+++ b/universum/modules/vcs/base_vcs.py
@@ -1,11 +1,12 @@
 import shutil
 
 from ..error_state import HasErrorState
+from ..project_directory import ProjectDirectory
 from ...lib.ci_exception import CiException
 from ...lib.utils import make_block
-from ..project_directory import ProjectDirectory
 
 __all__ = [
+    "BaseVcs",
     "BaseDownloadVcs",
     "BaseSubmitVcs",
     "BasePollVcs"
@@ -77,7 +78,7 @@ class BaseSubmitVcs(BaseVcs):
         :param description: Change description
         :param file_list: List of full paths to vcs to be submitted
         :param review: When set to True, create deletable review instead of submit
-        :param add_new: When set to True, add to submit vcs not yet present in repository
+        :param edit_only: When set to True, do not add new files to repository, just edit existing ones
         :return: Created change number
         """
         raise NotImplementedError
@@ -91,7 +92,7 @@ class BasePollVcs(BaseVcs):
     def get_changes(self, changes_reference=None, max_number='1'):
         """
         Get all (or last 'max_number' for a depot path) changes starting from reference state
-        :param changes_reference: Dictionary, where keys are depot paths and values are latest known changes
+        :param changes_reference: Dictionary, where keys are depot paths and values are the latest known changes
         :param max_number: Maximum number of changes for every depot path to return
         :return: Dictionary, where keys are depot paths and values are sets of changes
         """

--- a/universum/modules/vcs/git_vcs.py
+++ b/universum/modules/vcs/git_vcs.py
@@ -2,6 +2,7 @@
 import glob
 import importlib
 import os
+from typing import Any
 
 from .base_vcs import BaseVcs, BaseDownloadVcs, BasePollVcs, BaseSubmitVcs
 from ..error_state import HasErrorState
@@ -17,7 +18,7 @@ __all__ = [
     "GitPollVcs"
 ]
 
-git = None
+git: Any = None
 
 
 def catch_git_exception(ignore_if=None):
@@ -146,7 +147,7 @@ class GitMainVcs(GitVcs, BaseDownloadVcs):
 
     def _diff_against_reference_commit(self, commit_id):
         """Details. Depending on a 'git' version 'rename file' operation generates
-        different output. It could be sequence of 'add' and 'delete' or single
+        different output. It could be a sequence of 'add' and 'delete' or single
         'rename' operation.
         """
 
@@ -187,6 +188,9 @@ class GitMainVcs(GitVcs, BaseDownloadVcs):
         self.check_out()
         if self.settings.cherrypick_id:
             self.cherry_pick()
+
+    def copy_cl_files_and_revert(self):
+        raise RuntimeError("Git doesn't support calculating diff for code report steps.")
 
 
 class GitSubmitVcs(GitVcs, BaseSubmitVcs, HasErrorState):

--- a/universum/modules/vcs/git_vcs.py
+++ b/universum/modules/vcs/git_vcs.py
@@ -174,7 +174,7 @@ class GitMainVcs(GitVcs, BaseDownloadVcs):
                                "repo_path": diff_record[1],
                                "local_path": utils.parse_path(diff_record[-1], self.settings.project_root)})
             except IndexError:
-                self.out.log_stderr(line)
+                self.out.log_exception(line)
 
         return result
 

--- a/universum/modules/vcs/git_vcs.py
+++ b/universum/modules/vcs/git_vcs.py
@@ -174,7 +174,7 @@ class GitMainVcs(GitVcs, BaseDownloadVcs):
                                "repo_path": diff_record[1],
                                "local_path": utils.parse_path(diff_record[-1], self.settings.project_root)})
             except IndexError:
-                self.out.log_exception(line)
+                self.out.log_error(line)
 
         return result
 

--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -459,7 +459,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
         except P4Exception as e:
             if "already committed" in str(e) and self.swarm and len(self.shelve_cls) == 1:
                 self.out.log("CL already committed")
-                self.out.set_build_title("CL already committed")
+                self.out.set_build_status("CL already committed")
                 self.swarm = None
                 raise SilentAbortException(application_exit_code=0) from e  # This scenario does not fail build
             raise

--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -521,7 +521,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
                     raise
                 self.out.log(f"Getting file diff via 'p4 opened' failed after {timeout} seconds timeout")
         else:
-            self.out.log_stderr("Calculating file diff failed, leaving blank")
+            self.out.log_exception("Calculating file diff failed, leaving blank")
             return None
 
         for entry in opened_files:

--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -125,7 +125,7 @@ class PerforceVcs(base_vcs.BaseVcs, HasOutput, HasStructure, HasErrorState):
             raise SilentAbortException()
 
     def finalize(self):
-        with Uninterruptible(self.out.log_exception) as run:
+        with Uninterruptible(self.out.log_error) as run:
             run(self.disconnect)
             run(super().finalize)
 
@@ -521,7 +521,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
                     raise
                 self.out.log(f"Getting file diff via 'p4 opened' failed after {timeout} seconds timeout")
         else:
-            self.out.log_exception("Calculating file diff failed, leaving blank")
+            self.out.log_error("Calculating file diff failed, leaving blank")
             return None
 
         for entry in opened_files:
@@ -650,7 +650,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
                 self.structure.fail_current_block(e.value)
 
     def finalize(self):
-        with Uninterruptible(self.out.log_exception) as run:
+        with Uninterruptible(self.out.log_error) as run:
             if self.settings.force_clean:
                 run(self.connect)
                 run(self.clean_workspace)

--- a/universum/modules/vcs/perforce_vcs.py
+++ b/universum/modules/vcs/perforce_vcs.py
@@ -460,7 +460,7 @@ class PerforceMainVcs(PerforceWithMappings, base_vcs.BaseDownloadVcs):
         except P4Exception as e:
             if "already committed" in str(e) and self.swarm and len(self.shelve_cls) == 1:
                 self.out.log("CL already committed")
-                self.out.report_build_status("CL already committed")
+                self.out.set_build_title("CL already committed")
                 self.swarm = None
                 raise SilentAbortException(application_exit_code=0) from e  # This scenario does not fail build
             raise


### PR DESCRIPTION
1. Reordered and grouped methods, renamed them to make naming consistent. Now names correspond to what methods really do.
2. Added type annotations, documentation and fixed issues found by PyCharm inspections for affected files
3. Made some methods protected
4. Changed interface of the "log_summary_step" (previously report_step) function to make it explicit