### PR TITLE
fix(report): set exit code even if reporting crashes

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -239,6 +239,6 @@ configs = Configuration([dict(name="Unsuccessful step", command=["exit", "1"])])
     perforce_environment.settings.Swarm.server_url = "some_server"
     perforce_environment.settings.Swarm.review_id = "some_id"
     perforce_environment.settings.Swarm.change = perforce_environment.settings.PerforceMainVcs.shelve_cls[0]
-    perforce_environment.settings.Reporter.fail_unsuccessful = True
+    perforce_environment.settings.Main.fail_unsuccessful = True
 
     perforce_environment.run(expect_failure=True)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -226,3 +226,19 @@ configs = Configuration([Step(name="Step one", command=["ls", "-l"])])
     repo_state = (env.artifact_dir / 'REPOSITORY_STATE.txt').read_text()
     assert p4_files[0].name in repo_state
     assert p4_files[1].name in repo_state
+
+
+def test_exit_code_failed_report(perforce_environment: P4TestEnvironment):
+    config = """
+from universum.configuration_support import Configuration
+
+configs = Configuration([dict(name="Unsuccessful step", command=["exit", "1"])])
+"""
+    perforce_environment.shelve_config(config)
+    perforce_environment.settings.MainVcs.report_to_review = True
+    perforce_environment.settings.Swarm.server_url = "some_server"
+    perforce_environment.settings.Swarm.review_id = "some_id"
+    perforce_environment.settings.Swarm.change = perforce_environment.settings.PerforceMainVcs.shelve_cls[0]
+    perforce_environment.settings.Reporter.fail_unsuccessful = True
+
+    perforce_environment.run(expect_failure=True)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -229,6 +229,10 @@ configs = Configuration([Step(name="Step one", command=["ls", "-l"])])
 
 
 def test_exit_code_failed_report(perforce_environment: P4TestEnvironment):
+    """
+    This test checks for previous bug where exceptions during result reporting led to exit code 0
+    even when '--fail-unsuccessful' option was enabled (and some steps failed)
+    """
     config = """
 from universum.configuration_support import Configuration
 

--- a/universum/main.py
+++ b/universum/main.py
@@ -43,6 +43,8 @@ class Main(HasOutput):
                                      help="Only applies to build steps where ``code_report=True``; "
                                           "disables calculating analysis diff for changed files, "
                                           "in this case full analysis report will be published")
+        argument_parser.add_argument("--fail-unsuccessful", action="store_true", dest="fail_unsuccessful",
+                                     help="Return non-zero exit code if any step failed")
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -88,7 +90,9 @@ class Main(HasOutput):
                     self.code_report_collector.repo_diff = repo_diff
             self.code_report_collector.report_code_report_results()
         self.artifacts.report_artifacts()
-        self.reporter.report_build_result()
+        result = self.reporter.report_build_result()
+        if self.settings.fail_unsuccessful and not result:
+            raise SilentAbortException(1)
 
     def finalize(self) -> None:
         if self.settings.no_finalize:

--- a/universum/modules/reporter.py
+++ b/universum/modules/reporter.py
@@ -120,9 +120,7 @@ class Reporter(HasOutput, HasStructure):
 
         if not self.observers:
             self.out.log("Nowhere to report. Skipping...")
-            if is_successful:
-                return True
-            return False
+            return is_successful
 
         if is_successful:
             self.out.log("Reporting successful build...")
@@ -152,9 +150,7 @@ class Reporter(HasOutput, HasStructure):
             for observer in self.observers:
                 observer.code_report_to_review(self.code_report_comments)
 
-        if is_successful:
-            return True
-        return False
+        return is_successful
 
     def _report_steps_recursively(self, block: Block, text: str, indent: str) -> Tuple[str, bool]:
         has_children: bool = bool(block.children)

--- a/universum/modules/reporter.py
+++ b/universum/modules/reporter.py
@@ -1,12 +1,11 @@
 from collections import defaultdict
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple
 
 from typing_extensions import TypedDict
 
 from . import automation_server
 from .output import HasOutput
 from .structure_handler import HasStructure, Block
-from ..lib.ci_exception import SilentAbortException
 from ..lib.gravity import Dependency
 from ..lib.utils import make_block
 

--- a/universum/modules/reporter.py
+++ b/universum/modules/reporter.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 from typing_extensions import TypedDict
 
@@ -130,11 +130,11 @@ class Reporter(HasOutput, HasStructure):
                 text = "Sending comment skipped. " + \
                        "To report build success, use '--report-build-success' option"
                 self.out.log(text)
-                text = None
+                text = ""
         else:
             self.out.log("Reporting failed build...")
 
-        if text is not None:
+        if text:
             if not self.settings.report_start:
                 text += "\n\n" + self.automation_server.report_build_location()
 


### PR DESCRIPTION
1. Move 'fail_unsuccessful' option that changes program behavior to Main module
2. Change 'pass_errors=False' in result reporting to explicit exception handling for the guaranteed return value
3. Fix bug caused by p.2
4. Fix typing warning