### PR TITLE
fix(test): new docker engine version compatibility

### DIFF
--- a/tests/deployment_utils.py
+++ b/tests/deployment_utils.py
@@ -42,7 +42,8 @@ class ExecutionEnvironment:
         if self._container:
             self.request.raiseerror("Container is already running, no dirs can be bound!")
         for directory in directories:
-            self._volumes[directory] = {'bind': directory, 'mode': 'rw'}
+            absolute_dir = str(pathlib.Path(directory).absolute())
+            self._volumes[absolute_dir] = {'bind': absolute_dir, 'mode': 'rw'}
 
     def add_environment_variables(self, variables):
         if self._container:


### PR DESCRIPTION
After some update the docker engine started to require passing full
paths to bind mounts when starting the container.

The issue is reproduced on version 23.0.2. The error message from the
docker engine is the following: "invalid volume specification:
'.work:.work:rw': invalid mount config for type "volume": invalid mount
path: '.work' mount path must be absolute".
