### PR TITLE
fix(report): remove redundant file

### DIFF
--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -92,9 +92,6 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
                 if text:
                     report = json.loads(text)
 
-            json_file: TextIO = self.artifacts.create_text_file("Static_analysis_report.json")
-            json_file.write(json.dumps(report, indent=4))
-
             issue_count: int
             if not report and report != []:
                 self.out.log_error("There are no results in code report file. Something went wrong.")


### PR DESCRIPTION
Static_analysis_report.json is not used for core report functionality, but is added to artifacts and creates misleading assumption that it has some deeper meaning
As far as I can tell, the only use for it is for debug purposes

Resolves #785 