### PR TITLE
fix(workflow): disable link previews in TG bot

### DIFF
--- a/.github/workflows/telegram-bot.yml
+++ b/.github/workflows/telegram-bot.yml
@@ -63,7 +63,7 @@ jobs:
         fi
 
         if [[ ! -z $TEXT ]]; then
-          curl --get --data-urlencode "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" \
+          curl --get --data-urlencode "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" --data-urlencode "disable_web_page_preview=True" \
           --data-urlencode "text=$TEXT" --data-urlencode "parse_mode=HTML" $URL
         fi
 


### PR DESCRIPTION
All previews refer to Universum main page anyway.