### PR TITLE
test: reformat test_conditional_steps.py

### DIFF
--- a/tests/test_conditional_steps.py
+++ b/tests/test_conditional_steps.py
@@ -1,171 +1,173 @@
-# pylint: disable = invalid-name
+# pylint: disable = invalid-name, redefined-outer-name
 
 import re
-import os
+import pathlib
+from typing import Generator, AnyStr, List, Optional
 
-from universum import __main__
+import pytest
+
 from universum.configuration_support import Step
+
+from .utils import LocalTestEnvironment
 
 
 class StepsInfo:
-    conditional_step = None
-    true_branch_step = None
-    false_branch_step = None
-    is_conditional_step_passed = False
+    conditional_step: Step
+    true_branch_step: Optional[Step]
+    false_branch_step: Optional[Step]
+    is_conditional_step_passed: bool
 
 
-def test_conditional_true_branch(tmpdir, capsys):
-    steps_info = get_conditional_steps_info(is_conditional_step_passed=True)
-    check_conditional_step(tmpdir, capsys, steps_info)
+class ConditionalStepsTestEnv(LocalTestEnvironment):
+
+    def __init__(self, tmp_path: pathlib.Path, capsys: pytest.CaptureFixture) -> None:
+        super().__init__(tmp_path, "main")
+        self.capsys = capsys
+
+    def build_conditional_steps_info(self, is_conditional_step_passed: bool) -> StepsInfo:
+        steps_info: StepsInfo = StepsInfo()
+
+        steps_info.conditional_step = self._build_conditional_step(is_conditional_step_passed)
+        steps_info.true_branch_step = self._build_true_branch_step()
+        steps_info.false_branch_step = self._build_false_branch_step()
+        steps_info.is_conditional_step_passed = is_conditional_step_passed
+
+        return steps_info
+
+    def check_conditional_step(self, steps_info) -> None:
+        self._write_config_file(steps_info)
+        self.run()
+
+        captured: pytest.CaptureResult[AnyStr] = self.capsys.readouterr()
+        conditional_succeeded_regexp: str = r"\] conditional.*Success.*\|   5\.2"
+        assert re.search(conditional_succeeded_regexp, captured.out, re.DOTALL)
+
+        self._check_conditional_step_artifacts_present(steps_info)
+        self._check_executed_step_artifacts_present(steps_info)
+        self._check_not_executed_step_artifacts_absent(steps_info)
+
+    def _build_conditional_step(self, is_conditional_step_passed: bool) -> Step:
+        conditional_step_name: str = "conditional"
+        conditional_step_artifact: str = f"{conditional_step_name}_artifact"
+        conditional_step_report_artifact: str = f"{conditional_step_name}_report_artifact"
+        conditional_step_exit_code: int = 0 if is_conditional_step_passed else 1
+        return Step(name=conditional_step_name,
+                    command=self._build_step_command(
+                        files_to_create=[conditional_step_artifact, conditional_step_report_artifact],
+                        exit_code=conditional_step_exit_code),
+                    artifacts=conditional_step_artifact,
+                    report_artifacts=conditional_step_report_artifact)
+
+    def _build_true_branch_step(self) -> Step:
+        true_branch_step_name: str = "true_branch"
+        true_branch_step_artifact: str = f"{true_branch_step_name}_artifact"
+        true_branch_step_report_artifact: str = f"{true_branch_step_name}_report_artifact"
+        return Step(name=true_branch_step_name,
+                    command=self._build_step_command(
+                        files_to_create=[true_branch_step_artifact, true_branch_step_report_artifact],
+                        exit_code=0),
+                    artifacts=true_branch_step_artifact,
+                    report_artifacts=true_branch_step_report_artifact)
+
+    def _build_false_branch_step(self) -> Step:
+        false_branch_step_name: str = "false_branch"
+        false_branch_step_artifact: str = f"{false_branch_step_name}_artifact"
+        false_branch_step_report_artifact: str = f"{false_branch_step_name}_report_artifact"
+        return Step(name=false_branch_step_name,
+                    command=self._build_step_command(
+                        files_to_create=[false_branch_step_artifact, false_branch_step_report_artifact],
+                        exit_code=0),
+                    artifacts=false_branch_step_artifact,
+                    report_artifacts=false_branch_step_report_artifact)
+
+    @staticmethod
+    def _build_step_command(files_to_create, exit_code) -> List[str]:
+        commands: List[str] = []
+        for f in files_to_create:
+            commands.append(f"touch {f}")
+        commands.append(f"exit {exit_code}")
+        return ["bash", "-c", ";".join(commands)]
+
+    def _write_config_file(self, steps_info) -> None:
+        true_branch_step: str = f"Step(**{str(steps_info.true_branch_step)})" \
+            if steps_info.true_branch_step else "None"
+        false_branch_step: str = f"Step(**{str(steps_info.false_branch_step)})" \
+            if steps_info.false_branch_step else "None"
+        config_lines: List[str] = [
+            "from universum.configuration_support import Configuration, Step",
+            f"true_branch_step = {true_branch_step}",
+            f"false_branch_step = {false_branch_step}",
+            f"conditional_step = Step(**{str(steps_info.conditional_step)})",
+
+            # `true/false_branch_steps` should be Python objects from this script
+            "conditional_step.is_conditional = True",
+            "conditional_step.if_succeeded = true_branch_step",
+            "conditional_step.if_failed = false_branch_step",
+
+            "configs = Configuration([conditional_step])"
+        ]
+        config: str = "\n".join(config_lines)
+
+        self.configs_file.write_text(config, "utf-8")
+
+    def _check_conditional_step_artifacts_present(self, steps_info: StepsInfo) -> None:
+        conditional_step: Step = steps_info.conditional_step
+        self._check_artifacts_presence(conditional_step, is_presence_expected=True)
+
+    def _check_executed_step_artifacts_present(self, steps_info: StepsInfo) -> None:
+        executed_step: Optional[Step] = steps_info.true_branch_step if steps_info.is_conditional_step_passed \
+            else steps_info.false_branch_step
+        self._check_artifacts_presence(executed_step, is_presence_expected=True)
+
+    def _check_not_executed_step_artifacts_absent(self, steps_info: StepsInfo) -> None:
+        not_executed_step: Optional[Step] = steps_info.false_branch_step if steps_info.is_conditional_step_passed \
+            else steps_info.true_branch_step
+        self._check_artifacts_presence(not_executed_step, is_presence_expected=False)
+
+    def _check_artifacts_presence(self, step: Optional[Step], is_presence_expected: bool):
+        if not step:  # branch step can be not set
+            return
+        for artifact in [step.artifacts, step.report_artifacts]:
+            artifact_path: pathlib.Path = self.artifact_dir / artifact
+            assert artifact_path.exists() == is_presence_expected
 
 
-def test_conditional_false_branch(tmpdir, capsys):
-    steps_info = get_conditional_steps_info(is_conditional_step_passed=False)
-    check_conditional_step(tmpdir, capsys, steps_info)
+@pytest.fixture()
+def test_env(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture) -> Generator[ConditionalStepsTestEnv, None, None]:
+    yield ConditionalStepsTestEnv(tmp_path, capsys)
+
+
+def test_conditional_true_branch(test_env: ConditionalStepsTestEnv) -> None:
+    steps_info: StepsInfo = test_env.build_conditional_steps_info(is_conditional_step_passed=True)
+    test_env.check_conditional_step(steps_info)
+
+
+def test_conditional_false_branch(test_env: ConditionalStepsTestEnv) -> None:
+    steps_info: StepsInfo = test_env.build_conditional_steps_info(is_conditional_step_passed=False)
+    test_env.check_conditional_step(steps_info)
 
 
 # https://github.com/Samsung/Universum/issues/744
 # Artifact will be collected only from the second executed step, the first one will be overwritten
 # Skipping checking file content to not overload tests with additional logic for incorrect behaviour check
-def test_same_artifact(tmpdir, capsys):
-    steps_info = get_conditional_steps_info(is_conditional_step_passed=True)
+def test_same_artifact(test_env: ConditionalStepsTestEnv) -> None:
+    steps_info: StepsInfo = test_env.build_conditional_steps_info(is_conditional_step_passed=True)
 
+    assert steps_info.true_branch_step
     steps_info.true_branch_step.command = steps_info.conditional_step.command
     steps_info.true_branch_step.artifacts = steps_info.conditional_step.artifacts
     steps_info.true_branch_step.report_artifacts = steps_info.conditional_step.report_artifacts
 
-    check_conditional_step(tmpdir, capsys, steps_info)
+    test_env.check_conditional_step(steps_info)
 
 
-def test_true_branch_chosen_but_absent(tmpdir, capsys):
-    steps_info = get_conditional_steps_info(is_conditional_step_passed=True)
+def test_true_branch_chosen_but_absent(test_env: ConditionalStepsTestEnv) -> None:
+    steps_info: StepsInfo = test_env.build_conditional_steps_info(is_conditional_step_passed=True)
     steps_info.true_branch_step = None
-    check_conditional_step(tmpdir, capsys, steps_info)
+    test_env.check_conditional_step(steps_info)
 
 
-def test_false_branch_chosen_but_absent(tmpdir, capsys):
-    steps_info = get_conditional_steps_info(is_conditional_step_passed=False)
+def test_false_branch_chosen_but_absent(test_env: ConditionalStepsTestEnv) -> None:
+    steps_info: StepsInfo = test_env.build_conditional_steps_info(is_conditional_step_passed=False)
     steps_info.false_branch_step = None
-    check_conditional_step(tmpdir, capsys, steps_info)
-
-
-def get_conditional_steps_info(is_conditional_step_passed):
-    steps_info = StepsInfo()
-
-    conditional_step_name = "conditional"
-    conditional_step_artifact = f"{conditional_step_name}_artifact"
-    conditional_step_report_artifact = f"{conditional_step_name}_report_artifact"
-    conditional_step_exit_code = 0 if is_conditional_step_passed else 1
-    steps_info.conditional_step = Step(
-        name=conditional_step_name,
-        command=build_step_command(files_to_create=[conditional_step_artifact, conditional_step_report_artifact],
-                                   exit_code=conditional_step_exit_code),
-        artifacts=conditional_step_artifact,
-        report_artifacts=conditional_step_report_artifact)
-    steps_info.is_conditional_step_passed = is_conditional_step_passed
-
-    true_branch_step_name = "true_branch"
-    true_branch_step_artifact = f"{true_branch_step_name}_artifact"
-    true_branch_step_report_artifact = f"{true_branch_step_name}_report_artifact"
-    steps_info.true_branch_step = Step(
-        name=true_branch_step_name,
-        command=build_step_command(files_to_create=[true_branch_step_artifact, true_branch_step_report_artifact],
-                                   exit_code=0),
-        artifacts=true_branch_step_artifact,
-        report_artifacts=true_branch_step_report_artifact)
-
-    false_branch_step_name = "false_branch"
-    false_branch_step_artifact = f"{false_branch_step_name}_artifact"
-    false_branch_step_report_artifact = f"{false_branch_step_name}_report_artifact"
-    steps_info.false_branch_step = Step(
-        name=false_branch_step_name,
-        command=build_step_command(files_to_create=[false_branch_step_artifact, false_branch_step_report_artifact],
-                                   exit_code=0),
-        artifacts=false_branch_step_artifact,
-        report_artifacts=false_branch_step_report_artifact)
-
-    return steps_info
-
-
-def build_step_command(files_to_create, exit_code):
-    commands = []
-    for f in files_to_create:
-        commands.append(f"touch {f}")
-    commands.append(f"exit {exit_code}")
-    return ["bash", "-c", ";".join(commands)]
-
-
-def write_config_file(tmpdir, conditional_steps_info):
-    true_branch_step = f"Step(**{str(conditional_steps_info.true_branch_step)})" \
-        if conditional_steps_info.true_branch_step else "None"
-    false_branch_step = f"Step(**{str(conditional_steps_info.false_branch_step)})" \
-        if conditional_steps_info.false_branch_step else "None"
-    config_lines = [
-        "from universum.configuration_support import Configuration, Step",
-        f"true_branch_step = {true_branch_step}",
-        f"false_branch_step = {false_branch_step}",
-        f"conditional_step = Step(**{str(conditional_steps_info.conditional_step)})",
-
-        # `true/false_branch_steps` should be Python objects from this script
-        "conditional_step.is_conditional = True",
-        "conditional_step.if_succeeded = true_branch_step",
-        "conditional_step.if_failed = false_branch_step",
-
-        "configs = Configuration([conditional_step])"
-    ]
-    config = "\n".join(config_lines)
-
-    config_file = tmpdir.join("configs.py")
-    config_file.write_text(config, "utf-8")
-
-    return config_file
-
-
-def check_conditional_step(tmpdir, capsys, steps_info):
-    config_file = write_config_file(tmpdir, steps_info)
-
-    artifacts_dir = tmpdir.join("artifacts")
-    params = ["-vt", "none",
-              "-fsd", str(tmpdir),
-              "-ad", str(artifacts_dir),
-              "--clean-build",
-              "-o", "console"]
-    params.extend(["-cfg", str(config_file)])
-
-    return_code = __main__.main(params)
-    assert return_code == 0
-
-    captured = capsys.readouterr()
-    conditional_succeeded_regexp = r"\] conditional.*Success.*\|   5\.2"
-    assert re.search(conditional_succeeded_regexp, captured.out, re.DOTALL)
-
-    artifacts_checker = ConditionalStepsArtifactChecker(artifacts_dir, steps_info)
-    artifacts_checker.check_conditional_step_artifacts_present()
-    artifacts_checker.check_executed_step_artifacts_present()
-    artifacts_checker.check_not_executed_step_artifacts_absent()
-
-
-class ConditionalStepsArtifactChecker:
-
-    def __init__(self, artifacts_dir, steps_info):
-        self._artifacts_dir = artifacts_dir
-        self._conditional_step = steps_info.conditional_step
-        self._executed_step = steps_info.true_branch_step if steps_info.is_conditional_step_passed \
-            else steps_info.false_branch_step
-        self._not_executed_step = steps_info.false_branch_step if steps_info.is_conditional_step_passed \
-            else steps_info.true_branch_step
-
-    def check_conditional_step_artifacts_present(self):
-        self._check_artifacts_presence(self._conditional_step, is_presence_expected=True)
-
-    def check_executed_step_artifacts_present(self):
-        self._check_artifacts_presence(self._executed_step, is_presence_expected=True)
-
-    def check_not_executed_step_artifacts_absent(self):
-        self._check_artifacts_presence(self._not_executed_step, is_presence_expected=False)
-
-    def _check_artifacts_presence(self, step, is_presence_expected):
-        if not step:  # branch step can be not set
-            return
-        for artifact in [step.artifacts, step.report_artifacts]:
-            assert os.path.exists(os.path.join(self._artifacts_dir, artifact)) == is_presence_expected
+    test_env.check_conditional_step(steps_info)


### PR DESCRIPTION
Reformatting the conditional steps tests to follow the common approach.
- Test logic was **not** changed
- `LocalTestEnvironment` infrastructure reused
- Existing infrastructure code was adopted to use the "environment" class approach
- Typing was added