### PR TITLE
fix(test): outdated dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             'mypy',
             'types-requests',
             'selenium==3.141',
+            'urllib3==1.26.15',  # This is required for selenium-3.141 to work correctly
             'types-PyYAML==6.0'
         ]
     },


### PR DESCRIPTION
Latest selenium version is 4.0.9; latest urllib3 version is 2.0.2. However, used selenium version is 3.141, and latest non-failing urllib3 version for running FF with this selenium version is 1.26.15
