### PR TITLE
feat(launcher): explicit warning about 'critical' flag ignoring on co…

### DIFF
--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -416,6 +416,9 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
 
         if self._is_conditional_step_with_children_present(self.project_config):
             raise CriticalCiException("Conditional step doesn't support children configuration")
+        if self._is_critical_conditional_step_present(self.project_config):
+            self.out.log("WARNING: 'critical' flag will be ignored for conditional step. "
+                         "Set it to the 'if_failed' branch step instead")
 
         return self.project_config
 
@@ -453,5 +456,19 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
             if Launcher._is_conditional_step_with_children_present(step.children) or \
                Launcher._is_conditional_step_with_children_present(step.if_succeeded) or \
                Launcher._is_conditional_step_with_children_present(step.if_failed):
+                return True
+        return False
+
+    @staticmethod
+    def _is_critical_conditional_step_present(
+            configuration: Optional[configuration_support.Configuration]) -> bool:
+        if not configuration:
+            return False
+        for step in configuration.configs:
+            if step.is_conditional and step.critical:
+                return True
+            if Launcher._is_critical_conditional_step_present(step.children) or \
+               Launcher._is_critical_conditional_step_present(step.if_succeeded) or \
+               Launcher._is_critical_conditional_step_present(step.if_failed):
                 return True
         return False

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -462,8 +462,9 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
         step_names: List[str] = []
         Launcher._append_critical_conditional_step_names_recursively(configuration, step_names)
         if step_names:
-            step_names_str: str = ",".join(step_names)
-            self.out.log(f"WARNING: 'critical' flag will be ignored for conditional steps: [{step_names_str}]. "
+            step_names = [f'\t* "{name}"' for name in step_names]
+            step_names_str: str = "\n".join(step_names)
+            self.out.log(f"WARNING: 'critical' flag will be ignored for conditional steps: \n{step_names_str}\n "
                          "Set it to the 'if_failed' branch step instead")
 
     @staticmethod
@@ -474,7 +475,7 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
             return
         for step in configuration.configs:
             if step.is_conditional and step.critical:
-                step_names.append(f'"{step.name}"')
+                step_names.append(step.name)
             Launcher._append_critical_conditional_step_names_recursively(step.children, step_names)
             Launcher._append_critical_conditional_step_names_recursively(step.if_succeeded, step_names)
             Launcher._append_critical_conditional_step_names_recursively(step.if_failed, step_names)

--- a/universum/modules/launcher.py
+++ b/universum/modules/launcher.py
@@ -470,7 +470,7 @@ class Launcher(ProjectDirectory, HasOutput, HasStructure, HasErrorState):
     @staticmethod
     def _get_critical_conditional_step_names_recursively(
             configuration: Optional[configuration_support.Configuration]) -> List[str]:
-        step_names = []
+        step_names: List[str] = []
         if not configuration:
             return step_names
         for step in configuration.configs:


### PR DESCRIPTION
Log example:
```
2. Processing project configs
 |   ==> Adding file .../test_conditional_step_critical0/artifacts/CONFIGS_DUMP.txt to artifacts...
 |   ==> WARNING: 'critical' flag will be ignored for conditional steps:
 |   	* "conditional"
 |    Set it to the 'if_failed' branch step instead
 └ [Success]
```