### PR TITLE
fix(swarm): quickfix for incorrect '404' response

### DIFF
--- a/universum/lib/utils.py
+++ b/universum/lib/utils.py
@@ -176,6 +176,8 @@ class Uninterruptible:
                 func(*args, **kwargs)
             except SilentAbortException as e:
                 self.return_code = max(self.return_code, e.application_exit_code)
+            except CiException as e:
+                self.error_logger(str(e))
             except (KeyboardInterrupt, SystemExit):
                 self.error_logger("Interrupted from outer scope\n")
                 self.return_code = 3

--- a/universum/lib/utils.py
+++ b/universum/lib/utils.py
@@ -176,8 +176,6 @@ class Uninterruptible:
                 func(*args, **kwargs)
             except SilentAbortException as e:
                 self.return_code = max(self.return_code, e.application_exit_code)
-            except CiException as e:
-                self.error_logger(str(e))
             except (KeyboardInterrupt, SystemExit):
                 self.error_logger("Interrupted from outer scope\n")
                 self.return_code = 3

--- a/universum/modules/vcs/swarm.py
+++ b/universum/modules/vcs/swarm.py
@@ -6,6 +6,7 @@ from ..error_state import HasErrorState
 from ..output import HasOutput
 from ..reporter import ReportObserver, Reporter
 from ...lib import utils
+from ...lib.utils import Uninterruptible
 from ...lib.ci_exception import CiException
 from ...lib.gravity import Dependency
 
@@ -193,14 +194,13 @@ class Swarm(ReportObserver, HasOutput, HasErrorState):
         self.post_comment(report_text)
 
     def code_report_to_review(self, report):
-        for path, issues in report.items():
-            abs_path = os.path.join(self.client_root, path)
-            if abs_path in self.mappings_dict:
-                for issue in issues:
-                    self.post_comment(issue['message'],
-                                      filename=self.mappings_dict[abs_path],
-                                      line=issue['line'],
-                                      no_notification=True)
+        with Uninterruptible(self.out.log_error) as run:
+            for path, issues in report.items():
+                abs_path = os.path.join(self.client_root, path)
+                if abs_path in self.mappings_dict:
+                    for issue in issues:
+                        run(self.post_comment, issue['message'], filename=self.mappings_dict[abs_path],
+                            line=issue['line'], no_notification=True)
 
     def report_result(self, result, report_text=None, no_vote=False):
         # Opening links, sent by Swarm


### PR DESCRIPTION
Currently Swarm server returns '404' when adding comments to newly added files in review, causing to report malfunction.