### PR TITLE
The originalUriBaseIds field support

### DIFF
--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -143,7 +143,7 @@ sarif_report_split_uri = """
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "my_path",
+                  "uri": "my_file",
                   "uriBaseId": "ROOTPATH"
                 },
                 "region": {
@@ -161,7 +161,7 @@ sarif_report_split_uri = """
       ],
       "originalUriBaseIds": {
         "ROOTPATH": {
-          "uri": "my_file"
+          "uri": "my_path"
         }
       }
     }

--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -123,6 +123,52 @@ sarif_report = """
 }
 """
 
+sarif_report_split_uri = """
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Checkstyle",
+          "semanticVersion": "8.43",
+          "version": "8.43"
+        }
+      },
+      "results": [
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "my_path",
+                  "uriBaseId": "ROOTPATH"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Error!"
+          },
+          "ruleId": "testRule"
+        }
+      ],
+      "originalUriBaseIds": {
+        "ROOTPATH": {
+          "uri": "my_file"
+        }
+      }
+    }
+  ]
+}
+"""
+
 config_uncrustify = """
 code_width = 120
 input_tab_size = 2
@@ -142,6 +188,7 @@ log_success = r'Issues not found'
     [[json_report], False],
     [[sarif_report_minimal], True],
     [[sarif_report], False],
+    [[sarif_report_split_uri], False],
     [[json_report_minimal, sarif_report_minimal], True],
     [[json_report, sarif_report], False],
     [[json_report_minimal, sarif_report], False],
@@ -151,6 +198,7 @@ log_success = r'Issues not found'
     'json_issues_found',
     'sarif_no_issues',
     'sarif_issues_found',
+    'sarif_split_uri_issues_found',
     'both_tested_no_issues',
     'both_tested_issues_in_both',
     'both_tested_issues_in_sarif',

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -3,6 +3,7 @@ import json
 import os
 import urllib.parse
 from copy import deepcopy
+from pathlib import Path
 from typing import Dict, List, Optional, TextIO, Tuple
 
 from . import artifact_collector, reporter
@@ -61,6 +62,8 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
         for run in report.get('runs', []):
             analyzer_data: Dict[str, str] = run.get('tool').get('driver')  # non-optional per definition
             who: str = f"{analyzer_data.get('name')} [{analyzer_data.get('version', '?')}]"
+            root_uri_base_ids: Dict[str, str] = {uri_base_id: root_path['uri'] for uri_base_id, root_path in
+                                                 run.get('originalUriBaseIds', {}).items()}
             for issue in run.get('results', []):
                 issue_count += 1
                 what: str = issue.get('message')
@@ -73,7 +76,17 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
                         if location_data.get('address'):
                             continue  # binary artifact can't be processed
                         raise ValueError("Unexpected lack of artifactLocation tag")
-                    path: str = urllib.parse.unquote(artifact_data.get('uri', ''))
+                    if artifact_data.get('uriBaseId'):
+                        uri = artifact_data.get('uri')
+                        if not uri:
+                            raise ValueError("Unexpected lack of uri tag")
+                        uri_base_id = artifact_data.get('uriBaseId', '')
+                        root_base_path: str = urllib.parse.urlparse(root_uri_base_ids.get(uri_base_id)).path
+                        if uri_base_id and not root_base_path:
+                            raise ValueError(f"Unexpected lack of 'originalUriBaseIds' value for {uri_base_id}")
+                        path = str(Path(root_base_path, uri))
+                    else:
+                        path = urllib.parse.unquote(artifact_data.get('uri', ''))
                     region_data = location_data.get('region')
                     if not region_data:
                         continue  # TODO: cover this case as comment to the file as a whole

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -62,8 +62,8 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
         for run in report.get('runs', []):
             analyzer_data: Dict[str, str] = run.get('tool').get('driver')  # non-optional per definition
             who: str = f"{analyzer_data.get('name')} [{analyzer_data.get('version', '?')}]"
-            root_uri_base_ids: Dict[str, str] = {uri_base_id: root_path['uri'] for uri_base_id, root_path in
-                                                 run.get('originalUriBaseIds', {}).items()}
+            root_uri_base_paths: Dict[str, str] = {uri_base_id: urllib.parse.urlparse(root_path['uri']).path for
+                                                   uri_base_id, root_path in run.get('originalUriBaseIds', {}).items()}
             for issue in run.get('results', []):
                 issue_count += 1
                 what: str = issue.get('message')
@@ -81,10 +81,10 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
                         if not uri:
                             raise ValueError("Unexpected lack of uri tag")
                         uri_base_id = artifact_data.get('uriBaseId', '')
-                        root_base_path: str = urllib.parse.urlparse(root_uri_base_ids.get(uri_base_id)).path
+                        root_base_path = root_uri_base_paths.get(uri_base_id, '')
                         if uri_base_id and not root_base_path:
                             raise ValueError(f"Unexpected lack of 'originalUriBaseIds' value for {uri_base_id}")
-                        path = str(Path(root_base_path, uri))
+                        path = str(Path(root_base_path, urllib.parse.unquote(uri)))
                     else:
                         path = urllib.parse.unquote(artifact_data.get('uri', ''))
                     region_data = location_data.get('region')


### PR DESCRIPTION
# Description

This change implements support for the SARIF-formatted report files containing the originalUriBaseIds field. 
Those reports include URI split into two records that need additional processing.

Resolves #824


# How Has This Been Tested?

This change was tested locally with the data samples included in the bug #824 
