### PR TITLE
fix(clang_format_analyzer): create parent folders for target file

### DIFF
--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -408,10 +408,8 @@ configs = Configuration([Step(critical=True)]) * Configuration([
 
 
 @pytest.mark.parametrize('analyzer, extra_args, tested_content', [
-    ['clang_format', ["--report-html"], source_code_c],
     ['clang_format', [], source_code_c],
 ], ids=[
-    "clang_format_html_file",
     "clang_format",
 ])
 def test_clang_format_analyzer_with_subfolder(runner_with_analyzers: UniversumRunner, analyzer,
@@ -432,4 +430,4 @@ def test_clang_format_analyzer_with_subfolder(runner_with_analyzers: UniversumRu
 
     log = runner_with_analyzers.run(ConfigData().add_analyzer(analyzer, args, extra_config).finalize())
     assert not re.findall(r'No such file or directory', log), f"'No such file or directory' is found in '{log}'"
-    assert re.findall(log_fail, log), f"'{log_success}' is not found in '{log}'"
+    assert re.findall(log_fail, log), f"'{log_fail}' is not found in '{log}'"

--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -405,3 +405,31 @@ configs = Configuration([Step(critical=True)]) * Configuration([
 
     env.run()
     stdout_checker.assert_absent_calls_with_param("${CODE_REPORT_FILE}")
+
+
+@pytest.mark.parametrize('analyzer, extra_args, tested_content', [
+    ['clang_format', ["--report-html"], source_code_c],
+    ['clang_format', [], source_code_c],
+], ids=[
+    "clang_format_html_file",
+    "clang_format",
+])
+def test_clang_format_analyzer_with_subfolder(runner_with_analyzers: UniversumRunner, analyzer,
+                        extra_args, tested_content):
+
+    root = runner_with_analyzers.local.root_directory
+    source_file = root / "subdir" / "source_file"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(tested_content)
+    common_args = [
+        "--result-file", "${CODE_REPORT_FILE}",
+        "--files", "subdir/source_file"
+    ]
+    (root / ".clang-format").write_text(config_clang_format)
+
+    args = common_args + extra_args
+    extra_config = "artifacts='./diff_temp/source_file.html'"
+
+    log = runner_with_analyzers.run(ConfigData().add_analyzer(analyzer, args, extra_config).finalize())
+    assert not re.findall(r'No such file or directory', log), f"'No such file or directory' is found in '{log}'"
+    assert re.findall(log_fail, log), f"'{log_success}' is not found in '{log}'"

--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -407,27 +407,18 @@ configs = Configuration([Step(critical=True)]) * Configuration([
     stdout_checker.assert_absent_calls_with_param("${CODE_REPORT_FILE}")
 
 
-@pytest.mark.parametrize('analyzer, extra_args, tested_content', [
-    ['clang_format', [], source_code_c],
-], ids=[
-    "clang_format",
-])
-def test_clang_format_analyzer_with_subfolder(runner_with_analyzers: UniversumRunner, analyzer,
-                        extra_args, tested_content):
-
+def test_clang_format_analyzer_with_subfolder(runner_with_analyzers: UniversumRunner):
     root = runner_with_analyzers.local.root_directory
     source_file = root / "subdir" / "source_file"
     source_file.parent.mkdir(parents=True, exist_ok=True)
-    source_file.write_text(tested_content)
+    source_file.write_text(source_code_c)
     common_args = [
         "--result-file", "${CODE_REPORT_FILE}",
         "--files", "subdir/source_file"
     ]
+
     (root / ".clang-format").write_text(config_clang_format)
+    log = runner_with_analyzers.run(ConfigData().add_analyzer("clang_format", common_args).finalize())
 
-    args = common_args + extra_args
-    extra_config = "artifacts='./diff_temp/source_file.html'"
-
-    log = runner_with_analyzers.run(ConfigData().add_analyzer(analyzer, args, extra_config).finalize())
     assert not re.findall(r'No such file or directory', log), f"'No such file or directory' is found in '{log}'"
     assert re.findall(log_fail, log), f"'{log_fail}' is not found in '{log}'"

--- a/universum/analyzers/clang_format.py
+++ b/universum/analyzers/clang_format.py
@@ -39,6 +39,7 @@ def main(settings: argparse.Namespace) -> List[utils.ReportData]:
         cmd = [settings.executable, src_file_absolute]
         _add_style_param_if_present(cmd, settings)
         output, _ = utils.run_for_output(cmd)
+        target_file_absolute.parent.mkdir(parents=True, exist_ok=True)
         with open(target_file_absolute, "w", encoding="utf-8") as output_file:
             output_file.write(output)
 


### PR DESCRIPTION
# Description
 
Resolves [#837](https://github.com/Samsung/Universum/issues/837)

Added creation of directories before opening a file in universum/analyzers/clang_format.py:43


# Checklist:

- [ ] My code follows the [PEP 8](https://www.python.org/dev/peps/pep-0008/)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
