### PR TITLE
fix(analyzers): use recursive glob setting

### DIFF
--- a/universum/analyzers/utils.py
+++ b/universum/analyzers/utils.py
@@ -120,7 +120,7 @@ def expand_files_argument(settings: argparse.Namespace) -> None:
     # TODO: subclass argparse.Action
     result: Set[str] = set()
     for pattern in settings.file_list:
-        file_list: List[str] = glob.glob(pattern)
+        file_list: List[str] = glob.glob(pattern, recursive=True)
         if not file_list:
             sys.stderr.write(f"Warning: no files found for input pattern {pattern}\n")
         else:


### PR DESCRIPTION
# Description

Used `recursive=True` parameter for glob function to search files by pattern recursively

Resolves [#839](https://github.com/Samsung/Universum/issues/839)


# How Has This Been Tested?

please follow the steps in the [#839](https://github.com/Samsung/Universum/issues/839) issue to confirm the fix 

# Checklist:

- [ ] My code follows the [PEP 8](https://www.python.org/dev/peps/pep-0008/)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
