### PR TITLE
Fix GitHub actions command injection

### DIFF
--- a/.github/workflows/telegram-bot.yml
+++ b/.github/workflows/telegram-bot.yml
@@ -41,31 +41,31 @@ jobs:
 
         if [[ ! -z "${{ github.event.pull_request }}" && "${{ github.event.action }}" == "opened" ]]; then
           ESCAPED_NAME=`echo -e "$PR_NAME" | sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
-          TEXT=`echo -e "<b>$PR_AUTHOR</b> created new <a href=\"$PR_URL\">PR#$PR_NUMBER</a> '$ESCAPED_NAME' to branch '$PR_BASE'"`
+          TEXT=`echo -e "<b>"$PR_AUTHOR"</b> created new <a href=\"$PR_URL\">PR#"$PR_NUMBER"</a> '"$ESCAPED_NAME"' to branch '"$PR_BASE"'"`
         elif [[ ! -z "${{ github.event.pull_request }}" && "${{ github.event.action }}" == "synchronize" ]]; then
-          TEXT=`echo -e "<b>$PR_AUTHOR</b> updated <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
+          TEXT=`echo -e "<b>"$PR_AUTHOR"</b> updated <a href=\"$PR_URL\">PR#"$PR_NUMBER"</a>"`
         elif [[ ! -z "${{ github.event.pull_request }}" && "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
-          TEXT=`echo -e "<b>$PR_MERGED</b> merged <a href=\"$PR_URL\">PR#$PR_NUMBER</a> to branch <b>'$PR_BASE'</b>"`
+          TEXT=`echo -e "<b>"$PR_MERGED"</b> merged <a href=\"$PR_URL\">PR#"$PR_NUMBER"</a> to branch <b>'"$PR_BASE"'</b>"`
         elif [[ ! -z "${{ github.event.pull_request }}" && "${{ github.event.action }}" == "closed" ]]; then
-          TEXT=`echo -e "<b>$PR_AUTHOR</b> closed <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
+          TEXT=`echo -e "<b>"$PR_AUTHOR"</b> closed <a href=\"$PR_URL\">PR#"$PR_NUMBER"</a>"`
 
         elif [[ ! -z "${{ github.event.comment }}" ]]; then
           ESCAPED_TEXT=`echo -e "$COMMENT_BODY"| sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
           if [[ ! -z "${{ github.event.pull_request }}" ]]; then
-            TEXT=`echo -e "<b>$COMMENT_AUTHOR</b> posted the following comment to file <i>$COMMENT_FILE</i> in <a href=\"$COMMENT_URL\">PR#$PR_NUMBER</a>:\n<i>$ESCAPED_TEXT</i>"`
+            TEXT=`echo -e "<b>"$COMMENT_AUTHOR"</b> posted the following comment to file <i>"$COMMENT_FILE"</i> in <a href=\"$COMMENT_URL\">PR#"$PR_NUMBER"</a>:\n<i>"$ESCAPED_TEXT"</i>"`
           else
-            TEXT=`echo -e "<b>$COMMENT_AUTHOR</b> posted the following comment to issue <a href=\"$COMMENT_URL\">#$COMMENT_NUMBER</a>:\n<i>$ESCAPED_TEXT</i>"`
+            TEXT=`echo -e "<b>"$COMMENT_AUTHOR"</b> posted the following comment to issue <a href=\"$COMMENT_URL\">#"$COMMENT_NUMBER"</a>:\n<i>"$ESCAPED_TEXT"</i>"`
           fi
 
         elif [[ ! -z "${{ github.event.review }}" && "$REVIEW_STATE" == "changes_requested" ]]; then
-          TEXT=`echo -e "<b>$REVIEW_AUTHOR</b> requested changes for <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
+          TEXT=`echo -e "<b>"$REVIEW_AUTHOR"</b> requested changes for <a href=\"$PR_URL\">PR#"$PR_NUMBER"</a>"`
         elif [[ ! -z "${{ github.event.review }}" && "$REVIEW_STATE" == "commented" && ! -z "$REVIEW_COMMENT" ]]; then
           ESCAPED_TEXT=`echo -e "$REVIEW_COMMENT"| sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
-          TEXT=`echo -e "<b>$REVIEW_AUTHOR</b> posted the following comment to <a href=\"$PR_URL\">PR#$PR_NUMBER</a>:\n<i>$ESCAPED_TEXT</i>"`
+          TEXT=`echo -e "<b>"$REVIEW_AUTHOR"</b> posted the following comment to <a href=\"$PR_URL\">PR#"$PR_NUMBER"</a>:\n<i>"$ESCAPED_TEXT"</i>"`
         elif [[ ! -z "${{ github.event.review }}" && "$REVIEW_STATE" != "commented" ]]; then
-          TEXT=`echo -e "<b>$REVIEW_AUTHOR</b> $REVIEW_STATE <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
+          TEXT=`echo -e "<b>"$REVIEW_AUTHOR"</b> "$REVIEW_STATE" <a href=\"$PR_URL\">PR#"$PR_NUMBER"</a>"`
         elif [[ -z "${{ github.event.review }}" && "${{ github.event.action }}" == "submitted" ]]; then
-          TEXT=`echo -e "Due to GitHub Actions bug we cannot identify, who approved <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
+          TEXT=`echo -e "Due to GitHub Actions bug we cannot identify, who approved <a href=\"$PR_URL\">PR#"$PR_NUMBER"</a>"`
 
         elif [[ ! -z "${{ github.event.workflow_run }}" && "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
           ESCAPED_TEXT=`echo -e "$UNIVERSUM_BRANCH"| sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
@@ -75,9 +75,9 @@ jobs:
           TEXT=`echo -e "<a href=\"$UNIVERSUM_LOG\">Universum run for branch "$ESCAPED_TEXT"</a> <b>FAILED</b>; commit "$ESCAPED_TEXT" "`
         fi
 
-        if [[ ! -z $TEXT ]]; then
+        if [[ ! -z "$TEXT" ]]; then
           curl --get --data-urlencode "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" --data-urlencode "disable_web_page_preview=True" \
-          --data-urlencode "text=$TEXT" --data-urlencode "parse_mode=HTML" $URL
+          --data-urlencode "text="$TEXT"" --data-urlencode "parse_mode=HTML" "$URL"
         fi
 
       env:

--- a/.github/workflows/telegram-bot.yml
+++ b/.github/workflows/telegram-bot.yml
@@ -77,7 +77,7 @@ jobs:
 
         if [[ ! -z "$TEXT" ]]; then
           curl --get --data-urlencode "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" --data-urlencode "disable_web_page_preview=True" \
-          --data-urlencode "text="$TEXT"" --data-urlencode "parse_mode=HTML" "$URL"
+          --data-urlencode "text=$TEXT" --data-urlencode "parse_mode=HTML" "$URL"
         fi
 
       env:

--- a/.github/workflows/telegram-bot.yml
+++ b/.github/workflows/telegram-bot.yml
@@ -68,9 +68,11 @@ jobs:
           TEXT=`echo -e "Due to GitHub Actions bug we cannot identify, who approved <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
 
         elif [[ ! -z "${{ github.event.workflow_run }}" && "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
-          TEXT=`echo -e "<a href=\"$UNIVERSUM_LOG\">Universum run for branch "$UNIVERSUM_BRANCH"</a> <b>SUCCEDED</b>; commit "$UNIVERSUM_BRANCH" "`
+          ESCAPED_TEXT=`echo -e "$UNIVERSUM_BRANCH"| sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
+          TEXT=`echo -e "<a href=\"$UNIVERSUM_LOG\">Universum run for branch "$ESCAPED_TEXT"</a> <b>SUCCEDED</b>; commit "$ESCAPED_TEXT" "`
         elif [[ ! -z "${{ github.event.workflow_run }}" && "${{ github.event.workflow_run.conclusion }}" == "failure" ]]; then
-          TEXT=`echo -e "<a href=\"$UNIVERSUM_LOG\">Universum run for branch "$UNIVERSUM_BRANCH"</a> <b>FAILED</b>; commit "$UNIVERSUM_BRANCH" "`
+          ESCAPED_TEXT=`echo -e "$UNIVERSUM_BRANCH"| sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
+          TEXT=`echo -e "<a href=\"$UNIVERSUM_LOG\">Universum run for branch "$ESCAPED_TEXT"</a> <b>FAILED</b>; commit "$ESCAPED_TEXT" "`
         fi
 
         if [[ ! -z $TEXT ]]; then

--- a/.github/workflows/telegram-bot.yml
+++ b/.github/workflows/telegram-bot.yml
@@ -40,37 +40,37 @@ jobs:
       run: |
 
         if [[ ! -z "${{ github.event.pull_request }}" && "${{ github.event.action }}" == "opened" ]]; then
-          ESCAPED_NAME=`echo -e "${{ env.PR_NAME }}" | sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
-          TEXT=`echo -e "<b>${{ env.PR_AUTHOR }}</b> created new <a href=\"${{ env.PR_URL }}\">PR#${{ env.PR_NUMBER }}</a> '$ESCAPED_NAME' to branch '${{ env.PR_BASE }}'"`
+          ESCAPED_NAME=`echo -e "$PR_NAME" | sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
+          TEXT=`echo -e "<b>$PR_AUTHOR</b> created new <a href=\"$PR_URL\">PR#$PR_NUMBER</a> '$ESCAPED_NAME' to branch '$PR_BASE'"`
         elif [[ ! -z "${{ github.event.pull_request }}" && "${{ github.event.action }}" == "synchronize" ]]; then
-          TEXT=`echo -e "<b>${{ env.PR_AUTHOR }}</b> updated <a href=\"${{ env.PR_URL }}\">PR#${{ env.PR_NUMBER }}</a>"`
+          TEXT=`echo -e "<b>$PR_AUTHOR</b> updated <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
         elif [[ ! -z "${{ github.event.pull_request }}" && "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
-          TEXT=`echo -e "<b>${{ env.PR_MERGED }}</b> merged <a href=\"${{ env.PR_URL }}\">PR#${{ env.PR_NUMBER }}</a> to branch <b>'${{ env.PR_BASE }}'</b>"`
+          TEXT=`echo -e "<b>$PR_MERGED</b> merged <a href=\"$PR_URL\">PR#$PR_NUMBER</a> to branch <b>'$PR_BASE'</b>"`
         elif [[ ! -z "${{ github.event.pull_request }}" && "${{ github.event.action }}" == "closed" ]]; then
-          TEXT=`echo -e "<b>${{ env.PR_AUTHOR }}</b> closed <a href=\"${{ env.PR_URL }}\">PR#${{ env.PR_NUMBER }}</a>"`
+          TEXT=`echo -e "<b>$PR_AUTHOR</b> closed <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
 
         elif [[ ! -z "${{ github.event.comment }}" ]]; then
-          ESCAPED_TEXT=`echo -e "${{ env.COMMENT_BODY }}"| sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
+          ESCAPED_TEXT=`echo -e "$COMMENT_BODY"| sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
           if [[ ! -z "${{ github.event.pull_request }}" ]]; then
-            TEXT=`echo -e "<b>${{ env.COMMENT_AUTHOR }}</b> posted the following comment to file <i>${{ env.COMMENT_FILE }}</i> in <a href=\"${{ env.COMMENT_URL }}\">PR#${{ env.PR_NUMBER }}</a>:\n<i>$ESCAPED_TEXT</i>"`
+            TEXT=`echo -e "<b>$COMMENT_AUTHOR</b> posted the following comment to file <i>$COMMENT_FILE</i> in <a href=\"$COMMENT_URL\">PR#$PR_NUMBER</a>:\n<i>$ESCAPED_TEXT</i>"`
           else
-            TEXT=`echo -e "<b>${{ env.COMMENT_AUTHOR }}</b> posted the following comment to issue <a href=\"${{ env.COMMENT_URL }}\">#${{ env.COMMENT_NUMBER }}</a>:\n<i>$ESCAPED_TEXT</i>"`
+            TEXT=`echo -e "<b>$COMMENT_AUTHOR</b> posted the following comment to issue <a href=\"$COMMENT_URL\">#$COMMENT_NUMBER</a>:\n<i>$ESCAPED_TEXT</i>"`
           fi
 
-        elif [[ ! -z "${{ github.event.review }}" && "${{ env.REVIEW_STATE }}" == "changes_requested" ]]; then
-          TEXT=`echo -e "<b>${{ env.REVIEW_AUTHOR }}</b> requested changes for <a href=\"${{ env.PR_URL }}\">PR#${{ env.PR_NUMBER }}</a>"`
-        elif [[ ! -z "${{ github.event.review }}" && "${{ env.REVIEW_STATE }}" == "commented" && ! -z "${{ env.REVIEW_COMMENT }}" ]]; then
-          ESCAPED_TEXT=`echo -e "${{ env.REVIEW_COMMENT }}"| sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
-          TEXT=`echo -e "<b>${{ env.REVIEW_AUTHOR }}</b> posted the following comment to <a href=\"${{ env.PR_URL }}\">PR#${{ env.PR_NUMBER }}</a>:\n<i>$ESCAPED_TEXT</i>"`
-        elif [[ ! -z "${{ github.event.review }}" && "${{ env.REVIEW_STATE }}" != "commented" ]]; then
-          TEXT=`echo -e "<b>${{ env.REVIEW_AUTHOR }}</b> ${{ env.REVIEW_STATE }} <a href=\"${{ env.PR_URL }}\">PR#${{ env.PR_NUMBER }}</a>"`
+        elif [[ ! -z "${{ github.event.review }}" && "$REVIEW_STATE" == "changes_requested" ]]; then
+          TEXT=`echo -e "<b>$REVIEW_AUTHOR</b> requested changes for <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
+        elif [[ ! -z "${{ github.event.review }}" && "$REVIEW_STATE" == "commented" && ! -z "$REVIEW_COMMENT" ]]; then
+          ESCAPED_TEXT=`echo -e "$REVIEW_COMMENT"| sed 's/\&/\&amp;/g' | sed 's/</\&lt;/g' | sed 's/>/\&gt;/g'`
+          TEXT=`echo -e "<b>$REVIEW_AUTHOR</b> posted the following comment to <a href=\"$PR_URL\">PR#$PR_NUMBER</a>:\n<i>$ESCAPED_TEXT</i>"`
+        elif [[ ! -z "${{ github.event.review }}" && "$REVIEW_STATE" != "commented" ]]; then
+          TEXT=`echo -e "<b>$REVIEW_AUTHOR</b> $REVIEW_STATE <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
         elif [[ -z "${{ github.event.review }}" && "${{ github.event.action }}" == "submitted" ]]; then
-          TEXT=`echo -e "Due to GitHub Actions bug we cannot identify, who approved <a href=\"${{ env.PR_URL }}\">PR#${{ env.PR_NUMBER }}</a>"`
+          TEXT=`echo -e "Due to GitHub Actions bug we cannot identify, who approved <a href=\"$PR_URL\">PR#$PR_NUMBER</a>"`
 
         elif [[ ! -z "${{ github.event.workflow_run }}" && "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
-          TEXT=`echo -e "<a href=\"${{ env.UNIVERSUM_LOG }}\">Universum run for branch '${{ env.UNIVERSUM_BRANCH }}'</a> <b>SUCCEDED</b>; commit ${{ env.UNIVERUM_COMMIT }} "`
+          TEXT=`echo -e "<a href=\"$UNIVERSUM_LOG\">Universum run for branch "$UNIVERSUM_BRANCH"</a> <b>SUCCEDED</b>; commit "$UNIVERSUM_BRANCH" "`
         elif [[ ! -z "${{ github.event.workflow_run }}" && "${{ github.event.workflow_run.conclusion }}" == "failure" ]]; then
-          TEXT=`echo -e "<a href=\"${{ env.UNIVERSUM_LOG }}\">Universum run for branch '${{ env.UNIVERSUM_BRANCH }}'</a> <b>FAILED</b>; commit ${{ env.UNIVERUM_COMMIT }} "`
+          TEXT=`echo -e "<a href=\"$UNIVERSUM_LOG\">Universum run for branch "$UNIVERSUM_BRANCH"</a> <b>FAILED</b>; commit "$UNIVERSUM_BRANCH" "`
         fi
 
         if [[ ! -z $TEXT ]]; then


### PR DESCRIPTION
# Description

Fix GitHub actions command injection
In the file telegram-bot.yml lines:
```
        elif [[ ! -z "${{ github.event.workflow_run }}" && "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
          TEXT=`echo -e "<a href=\"${{ env.UNIVERSUM_LOG }}\">Universum run for branch '${{ env.UNIVERSUM_BRANCH }}'</a> <b>SUCCEDED</b>; commit ${{ env.UNIVERUM_COMMIT }} "`
        elif [[ ! -z "${{ github.event.workflow_run }}" && "${{ github.event.workflow_run.conclusion }}" == "failure" ]]; then
          TEXT=`echo -e "<a href=\"${{ env.UNIVERSUM_LOG }}\">Universum run for branch '${{ env.UNIVERSUM_BRANCH }}'</a> <b>FAILED</b>; commit ${{ env.UNIVERUM_COMMIT }} "`
        fi
```
Can be command injection with untrusted env.UNIVERSUM_BRANCH input. See this [PR](https://github.com/Samsung/Universum/pull/841) for example.
An attacker can steal repo secrets that are stored in the env URL variable and maybe GITHUB_TOKEN

This PR fixes this problem with guide from [official github docs](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)
