### PR TITLE
fix(report): Parse data from sarif as URI

### DIFF
--- a/tests/test_code_report.py
+++ b/tests/test_code_report.py
@@ -169,6 +169,46 @@ sarif_report_split_uri = """
 }
 """
 
+sarif_report_uri = """
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Checkstyle",
+          "semanticVersion": "8.43",
+          "version": "8.43"
+        }
+      },
+      "results": [
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///my_path/my_file"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Error!"
+          },
+          "ruleId": "testRule"
+        }
+      ]
+    }
+  ]
+}
+"""
+
 config_uncrustify = """
 code_width = 120
 input_tab_size = 2
@@ -189,6 +229,7 @@ log_success = r'Issues not found'
     [[sarif_report_minimal], True],
     [[sarif_report], False],
     [[sarif_report_split_uri], False],
+    [[sarif_report_uri], False],
     [[json_report_minimal, sarif_report_minimal], True],
     [[json_report, sarif_report], False],
     [[json_report_minimal, sarif_report], False],
@@ -199,6 +240,7 @@ log_success = r'Issues not found'
     'sarif_no_issues',
     'sarif_issues_found',
     'sarif_split_uri_issues_found',
+    'sarif_uri',
     'both_tested_no_issues',
     'both_tested_issues_in_both',
     'both_tested_issues_in_sarif',

--- a/universum/modules/code_report_collector.py
+++ b/universum/modules/code_report_collector.py
@@ -65,17 +65,17 @@ class CodeReportCollector(ProjectDirectory, HasOutput, HasStructure):
                 if location_data.get('address'):
                     continue  # binary artifact can't be processed
                 raise ValueError("Unexpected lack of artifactLocation tag")
+            uri = artifact_data.get('uri')
+            if not uri:
+                raise ValueError("Unexpected lack of uri tag")
+            path = urllib.parse.unquote(urllib.parse.urlparse(uri).path)
             if artifact_data.get('uriBaseId'):
-                uri = artifact_data.get('uri')
-                if not uri:
-                    raise ValueError("Unexpected lack of uri tag")
+                # means path is relative, need to make absolute
                 uri_base_id = artifact_data.get('uriBaseId', '')
                 root_base_path = root_uri_base_paths.get(uri_base_id, '')
                 if uri_base_id and not root_base_path:
                     raise ValueError(f"Unexpected lack of 'originalUriBaseIds' value for {uri_base_id}")
-                path = str(Path(root_base_path, urllib.parse.unquote(uri)))
-            else:
-                path = urllib.parse.unquote(artifact_data.get('uri', ''))
+                path = str(Path(root_base_path) / path)
             region_data = location_data.get('region')
             if not region_data:
                 continue  # TODO: cover this case as comment to the file as a whole


### PR DESCRIPTION
Detekt has changed uri format for its sarif report to explicitly define file:/// schema: https://github.com/detekt/detekt/pull/6331/files

It seems Universum can't parse these updated links.
We need to modify core_report_collector to parse uri instead of just unquoting it.
