### PR TITLE
fix(tests): Fixes for p4 unit tests

### DIFF
--- a/tests/test_p4_exception_handling.py
+++ b/tests/test_p4_exception_handling.py
@@ -94,7 +94,5 @@ def test_p4_print_exception_in_sync(perforce_environment: P4TestEnvironment, std
 def test_p4_print_exception_already_committed_shelve(perforce_environment: P4TestEnvironment, stdout_checker: FuzzyCallChecker):
     cl = perforce_environment.vcs_client.make_a_change()
     perforce_environment.settings.PerforceMainVcs.shelve_cls = [cl]
-
-    # This is not the 'already committed' case of Swarm review, so it actually should fail
     perforce_environment.run(expect_failure=True)
     stdout_checker.assert_has_calls_with_param(f"Change {cl} is already committed.")

--- a/tests/test_p4_exception_handling.py
+++ b/tests/test_p4_exception_handling.py
@@ -91,12 +91,10 @@ def test_p4_print_exception_in_sync(perforce_environment: P4TestEnvironment, std
     stdout_checker.assert_has_calls_with_param(text)
 
 
-def test_p4_print_exception_wrong_shelve(perforce_environment: P4TestEnvironment, stdout_checker: FuzzyCallChecker):
+def test_p4_print_exception_already_committed_shelve(perforce_environment: P4TestEnvironment, stdout_checker: FuzzyCallChecker):
     cl = perforce_environment.vcs_client.make_a_change()
     perforce_environment.settings.PerforceMainVcs.shelve_cls = [cl]
 
     # This is not the 'already committed' case of Swarm review, so it actually should fail
     perforce_environment.run(expect_failure=True)
-    stdout_checker.assert_has_calls_with_param(
-        f"Errors during command execution( \"p4 unshelve -s {cl} -f\" )")
-    stdout_checker.assert_has_calls_with_param(f"[Error]: 'Change {cl} is already committed.'")
+    stdout_checker.assert_has_calls_with_param(f"Change {cl} is already committed.")

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -59,7 +59,7 @@ def test_p4_error_command_line_wrong_port(stdout_checker: FuzzyCallChecker,
                             "-p4d", perforce_workspace.depot,
                             "-jtu", "https://localhost/?%s"])
     assert result != 0
-    stdout_checker.assert_has_calls_with_param("TCP connect to 127.0.0.1:1024 failed.")
+    stdout_checker.assert_has_calls_with_param("Connect to server failed; check $P4PORT")
 
 
 def test_git_error_command_line_wrong_port(stdout_checker: FuzzyCallChecker,


### PR DESCRIPTION
Fixes for 2 unit tests that fall on CI.
1. `test_p4_error_command_line_wrong_port`
The test expected the error "TCP connect to 127.0.0.1:1024 failed." but the Universum output is: "Connect to server failed; check $P4PORT". The suggested solution is to change the value of `pattern_to_search` in the test.

2. `test_p4_print_exception_wrong_shelve`
The test expected f"Errors during command execution( \"p4 unshelve -s {cl} -f\" )" and f"[Error]: 'Change {cl} is already committed.'" but the Universum output just f"Change {cl} is already committed.".
The suggested solution is to change the name of the test to `test_p4_print_exception_already_committed_shelve` and the value of `pattern_to_search`.

**The reason is the new error output in p4python 2024.1.0.**
https://github.com/perforce/p4python/compare/2023.2.2...2024.1.0

**p4python==2023.2.258197 output:**
[P4.connect()] Connect to server failed; check $P4PORT.
TCP connect to 1666 failed.
connect: 127.0.0.1:1666: Connection refused

**p4python==2024.1.2625398 output:**
Connect to server failed; check $P4PORT.