### PR TITLE
fix(setup): loosen dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'lxml',
         'typing-extensions',
         'ansi2html',
-        'pyyaml==6.0'
+        'pyyaml>=6.0'
     ],
     extras_require={
         'p4': [p4],
@@ -59,7 +59,7 @@ setup(
             'types-requests',
             'selenium==3.141',
             'urllib3==1.26.15',  # This is required for selenium-3.141 to work correctly
-            'types-PyYAML==6.0',
+            'types-PyYAML>=6.0',
             'wheel'
         ]
     },


### PR DESCRIPTION
Some latest Ubuntu versions can only install pyyaml 6.02